### PR TITLE
[bug] `scene_gameplay`:fix_last_building_lacking_collision_detection

### DIFF
--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -265,7 +265,7 @@ void scene_gameplay_populate(
 
   scene->objects[0]->position.y = scene->player.position.y;
 
-  player_data->length_objects = scene->length_objects - 6;
+  player_data->length_objects = scene->length_objects - 5;
   player_data->objects = scene->objects + 2;
 }
 


### PR DESCRIPTION
- `scene_gameplay`
- - add last building to collision detection
- - fixes bug where the last building to be generated lacks collision detection