### PR TITLE
[bug] Metil 1 0 0 compatibility fixes

### DIFF
--- a/.github/workflows/continuous_integration_build.yml
+++ b/.github/workflows/continuous_integration_build.yml
@@ -18,6 +18,8 @@ env:
   key_cache_math_c: cache_math_c_0_0_0
   key_cache_metil: cache_metil_1_0_0
   key_cache_rand: cache_rand_0_0_0
+  target_device_version_macos: 15.5
+  target_standard_metal: metal3.2
 jobs:
   continuous_integration_build:
     runs-on: macos-latest
@@ -72,38 +74,38 @@ jobs:
           key: ${{ env.key_cache_rand }}
       - name: checkout_cer0
         if: steps.cache_restore_cer0.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: alic3dev/cer0
           path: cer0
       - name: checkout_clic3
         if: steps.cache_restore_clic3.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: alic3dev/clic3
           path: clic3
       - name: checkout_interrupt_handler
         if: steps.cache_restore_interrupt_handler.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: alic3dev/interrupt_handler
           path: interrupt_handler
       - name: checkout_math_c
         if: steps.cache_restore_math_c.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: alic3dev/math_c
           path: math_c
       - name: checkout_metil
         if: steps.cache_restore_metil.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: alic3dev/metil
           ref: metil_1_0_0
           path: metil
       - name: checkout_rand
         if: steps.cache_restore_rand.outputs.cache-hit != 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: alic3dev/rand
           path: rand

--- a/.github/workflows/continuous_integration_build.yml
+++ b/.github/workflows/continuous_integration_build.yml
@@ -111,24 +111,24 @@ jobs:
           path: rand
       - name: make_clic3
         if: steps.cache_restore_clic3.outputs.cache-hit != 'true'
-        run: cd clic3 && make clic3_dylib
+        run: cd clic3 && make clic3_dylib target_device_version=${{ env.target_device_version_macos }}
       - name: make_cer0
         if: steps.cache_restore_cer0.outputs.cache-hit != 'true'
-        run: cd cer0 && make cer0_dylib
+        run: cd cer0 && make cer0_dylib target_device_version=${{ env.target_device_version_macos }}
       - name: make_interrupt_handler
         if: steps.cache_restore_interrupt_handler.outputs.cache-hit != 'true'
-        run: cd interrupt_handler && make interrupt_handler_dylib
+        run: cd interrupt_handler && make interrupt_handler_dylib target_device_version=${{ env.target_device_version_macos }}
       - name: make_math_c
         if: steps.cache_restore_math_c.outputs.cache-hit != 'true'
-        run: cd math_c && make math_c_dylib
+        run: cd math_c && make math_c_dylib target_device_version=${{ env.target_device_version_macos }}
       - name: make_metil
         if: steps.cache_restore_metil.outputs.cache-hit != 'true'
-        run: cd metil && make metil
+        run: cd metil && make metil target_device_version=${{ env.target_device_version_macos }} target_standard_metal=${{ env.target_standard_metal }}
       - name: make_rand
         if: steps.cache_restore_rand.outputs.cache-hit != 'true'
-        run: cd rand && make rand_dylib
+        run: cd rand && make rand_dylib target_device_version=${{ env.target_device_version_macos }}
       - name: make_c938
-        run: cd c938 && make disable_metal_fast_options=1
+        run: cd c938 && make disable_metal_fast_options=1 target_device_version=${{ env.target_device_version_macos }} target_standard_metal=${{ env.target_standard_metal }}
       - name: cache_save_cer0
         id: cache_save_cer0
         if: ${{ env.enabled_caching == '1' && env.enabled_caching_cer0 == '1' && steps.cache_restore_cer0.outputs.cache-hit != 'true' }}

--- a/makefile
+++ b/makefile
@@ -49,19 +49,19 @@ directory_rand=../rand
 directory_rand_include=${directory_rand}/include
 
 ifeq (${debug}, 1)
-	directory_cer0_library=${directory_cer0}/library_debug
-	directory_clic3_library=${directory_clic3}/library_debug
-	directory_interrupt_handler_library=${directory_interrupt_handler}/library_debug
-	directory_math_c_library=${directory_math_c}/library_debug
+	directory_cer0_library=${directory_cer0}/library/macos/debug
+	directory_clic3_library=${directory_clic3}/library/macos/debug
+	directory_interrupt_handler_library=${directory_interrupt_handler}/library/macos/debug
+	directory_math_c_library=${directory_math_c}/library/macos/debug
 	directory_metil_library=${directory_metil}/library_debug
-	directory_rand_library=${directory_rand}/library_debug
+	directory_rand_library=${directory_rand}/library/macos/debug
 else
-	directory_cer0_library=${directory_cer0}/library
-	directory_clic3_library=${directory_clic3}/library
-	directory_interrupt_handler_library=${directory_interrupt_handler}/library
-	directory_math_c_library=${directory_math_c}/library
+	directory_cer0_library=${directory_cer0}/library/macos/release
+	directory_clic3_library=${directory_clic3}/library/macos/release
+	directory_interrupt_handler_library=${directory_interrupt_handler}/library/macos/release
+	directory_math_c_library=${directory_math_c}/library/macos/release
 	directory_metil_library=${directory_metil}/library
-	directory_rand_library=${directory_rand}/library
+	directory_rand_library=${directory_rand}/library/macos/release
 endif
 
 directory_metal=metal
@@ -74,7 +74,17 @@ directory_app_contents_macos=${directory_app_contents}/MacOS
 directory_app_contents_resources=${directory_app_contents}/Resources
 directory_app_contents_resources_textures=${directory_app_contents_resources}/textures
 
-directory_macos_sdk=${shell xcrun --show-sdk-path}
+
+target_device=mac
+ifndef target_device_version
+	target_device_version=26.1
+endif
+
+ifndef target_standard_metal
+target_standard_metal=metal4.0
+endif
+
+directory_sdk=${shell xcrun --sdk macosx${target_device_version} --show-sdk-path}
 
 ifeq (${debug}, 1)
 	file_cer0_library=${directory_cer0_library}/cer0_debug.${version_target_cer0}.dylib
@@ -137,19 +147,15 @@ files_textures_resources=${patsubst ${directory_textures}/%,${directory_app_cont
 url_content=https://content.alic3.dev/${name}
 url_content_textures=${url_content}/textures
 
-target_device=mac
-ifndef target_macos_version
-	target_macos_version=26.0
-endif
-target_macos_version_metal=${target_macos_version}
-target_platform=arm64-apple-macos${target_macos_version}
-target_platform_metal=air64-apple-macos${target_macos_version_metal}
+target_device_version_metal=${target_device_version}
+target_platform=arm64-apple-macos${target_device_version}
+target_platform_metal=air64-apple-macos${target_device_version_metal}
 
 frameworks=Metal MetalKit GameController CoreAudio CoreGraphics CoreText
 
 cc=clang
 c_flags_includes=-I${directory_include} -I${directory_cer0_include} -I${directory_clic3_include} -I${directory_interrupt_handler_include} -I${directory_metil_include} -I${directory_rand_include}
-c_flags_platform=-target ${target_platform} -isysroot ${directory_macos_sdk}
+c_flags_platform=-target ${target_platform} -isysroot ${directory_sdk}
 
 c_flags_objc_debug=-O0 -g -v
 c_flags_debug=${c_flags_objc_debug} -da -Q
@@ -175,8 +181,8 @@ strip_flags=-x
 metal=xcrun -sdk macosx metal
 metal_ar=xcrun -sdk macosx metal-ar
 metallib=xcrun -sdk macosx metallib
-metal_flags_common=-target ${target_platform_metal}
-metal_flags=${metal_flags_common} -I${directory_include} -I${directory_clic3_include} -I${directory_metil_include} -isysroot ${directory_macos_sdk}
+metal_flags_common=-target ${target_platform_metal} -std=${target_standard_metal}
+metal_flags=${metal_flags_common} -I${directory_include} -I${directory_clic3_include} -I${directory_metil_include} -isysroot ${directory_sdk}
 
 ifneq (${disable_metal_fast_options}, 1)
 	metal_flags:=${metal_flags} -fmetal-math-mode\=fast -fmetal-math-fp32-functions\=fast
@@ -242,7 +248,7 @@ ${directory_objects_objc}/%.o: ${directory_sources}/%.m
 
 ${directory_app_contents_resources}/%.storyboardc: ${directory_storyboards}/%.storyboard
 	mkdir -p ${directory_app_contents_resources}
-	ibtool --module ${name} --target-device ${target_device} --minimum-deployment-target ${target_macos_version} --output-format human-readable-text $< --compilation-directory ${directory_app_contents_resources}	
+	ibtool --module ${name} --target-device ${target_device} --minimum-deployment-target ${target_device_version} --output-format human-readable-text $< --compilation-directory ${directory_app_contents_resources}	
 
 ${file_output_info_plist}: ${file_info_plist}
 	mkdir -p ${directory_app_contents}

--- a/sources/generate/generate_buildings.m
+++ b/sources/generate/generate_buildings.m
@@ -201,8 +201,8 @@ void generate_buildings(
     if (
       index_renderable == 2
     ) {
-      data->color.x = 1.0f;
-      data->color.y = 1.0f;
+      data->color.x = 0.0f;
+      data->color.y = 0.0f;
       data->color.z = 1.0f;
       data->color.w = 1.0f;
     } else {

--- a/sources/mesh/mesh_crosshair.c
+++ b/sources/mesh/mesh_crosshair.c
@@ -11,8 +11,6 @@ void mesh_crosshair_initialize(
 ) {
   metil_mesh_initialize(mesh);
 
-  mesh->positioning = metil_mesh_positioning_static;
-
   mesh->size.x = 0.02f;
   mesh->size.y = 0.02f;
   mesh->size.z = 0.0f;

--- a/sources/mesh/mesh_hud_item.c
+++ b/sources/mesh/mesh_hud_item.c
@@ -11,8 +11,6 @@ void mesh_hud_item_initialize(
 ) {
   metil_mesh_initialize(mesh);
 
-  mesh->positioning = metil_mesh_positioning_static;
-
   mesh->size.x = 0.2f;
   mesh->size.y = 0.05f;
   mesh->size.z = 0.0f;

--- a/sources/mesh/mesh_player.c
+++ b/sources/mesh/mesh_player.c
@@ -28,8 +28,6 @@ void mesh_player_initialize(
     (mesh->length_vertices - 1) * 3
   );
 
-  mesh->positioning = metil_mesh_positioning_player;
-
   mesh->indices = realloc(
     mesh->indices,
     sizeof(unsigned int) *

--- a/sources/objects/object_crosshair.m
+++ b/sources/objects/object_crosshair.m
@@ -21,6 +21,8 @@ void object_crosshair_initialize(
     &object->mesh
   );
 
+  object->positioning = metil_positioning_static;
+
   object->type_primitive = (
     MTLPrimitiveTypeLine
   );

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -71,16 +71,29 @@ void scene_gameplay_initialize(
   );
 
   for (
-    unsigned char index_renderable = scene->length_renderables - 4;
-    index_renderable < scene->length_renderables;
+    unsigned char index_renderable = 1;
+    index_renderable < 4;
     ++index_renderable
   ) {
     object = scene->renderables[
       index_renderable
     ].renderable;
 
+    mesh_hud_item_initialize(
+      &object->mesh
+    );
+
+    metil_object_buffers_initialize(
+      object,
+      metal_device
+    );
 
     object->positioning = metil_positioning_static;
+
+    object->index_pipeline_render = (
+      c938_pipeline_index_hud_item
+    );
+  }
 
   scene->length_textures = 1;
   scene->textures = realloc(
@@ -129,25 +142,13 @@ void scene_gameplay_initialize(
 
   object = (
     scene->renderables[
-      scene->length_renderables -
       1
     ].renderable
   );
 
-  mesh_hud_item_initialize(
-    &object->mesh  
-  );
-
-  metil_object_buffers_initialize(
-    object,
-    metal_device
-  );
-
   data = object->data.contents;
 
-  data->id = (
-    scene->length_renderables - 1
-  );
+  data->id = 1;
 
   data->noise = 2000;
 
@@ -157,21 +158,12 @@ void scene_gameplay_initialize(
 
   object = (
     scene->renderables[
-      scene->length_renderables - 2
+      2
     ].renderable
   );
 
-  mesh_hud_item_initialize(
-    &object->mesh  
-  );
-
-  metil_object_buffers_initialize(
-    object,
-    metal_device
-  );
-
   data = object->data.contents;
-  data->id = scene->length_renderables - 2;
+  data->id = 2;
 
   data->noise = 1.0f;
 
@@ -181,31 +173,30 @@ void scene_gameplay_initialize(
 
   object = (
     scene->renderables[
-      scene->length_renderables - 3
+      3
     ].renderable
-  );
-
-  mesh_hud_item_initialize(
-    &object->mesh
-  );
-
-  metil_object_buffers_initialize(
-    object,
-    metal_device
   );
 
   data = object->data.contents;
 
-  data->id = (
-    scene->length_renderables -
-    3
-  );
+  data->id = 3;
 
   data->noise = 2000;
 
   object->position.x = -0.9f;
   object->position.y = -0.7f;
   object->position.z = 0.0f;
+
+  object = (
+    scene->renderables[
+      4
+    ].renderable
+  );
+
+  object_crosshair_initialize(
+    object,
+    scene->metal_device
+  );
 
   scene_gameplay_populate(
     scene,
@@ -235,14 +226,14 @@ void scene_gameplay_populate(
     player_data
   );
 
-  unsigned short int iterator_id = 1;
+  unsigned short int iterator_id = 5;
 
   if (
-    scene->renderables[1].renderable != (void*)0
+    scene->renderables[5].renderable != (void*)0
   ) {
     for (
-      unsigned short int index_renderable = 1;
-      index_renderable < scene->length_renderables - 4;
+      unsigned short int index_renderable = 5;
+      index_renderable < scene->length_renderables;
       ++index_renderable
     ) {
       metil_object_destroy(
@@ -272,38 +263,6 @@ void scene_gameplay_populate(
       );
     }
 
-    struct metil_object* objects[4];
-
-    for (
-      unsigned char index_renderable = 0;
-      index_renderable < 4;
-      ++index_renderable
-    ) {
-      objects[
-        index_renderable
-      ] = scene->renderables[
-        scene->length_renderables -
-        index_renderable -
-        1
-      ].renderable;
-    }
-
-    for (
-      unsigned char index_renderable = 0;
-      index_renderable < 4;
-      ++index_renderable
-    ) {
-      scene->renderables[
-        length_renderables -
-        index_renderable -
-        1
-      ].renderable = (
-        objects[
-          index_renderable
-        ]
-      );
-    }
-
     if (
       scene->length_renderables > length_renderables
     ) {
@@ -319,15 +278,15 @@ void scene_gameplay_populate(
 
   generate_buildings(
     scene->metal_device,
-    scene->renderables + 1,
-    scene->length_renderables - 5,
+    scene->renderables + 5,
+    scene->length_renderables,
     scene->textures[0],
-    1
+    5
   );
 
   struct metil_object* object = (
     scene->renderables[
-      2
+      6
     ].renderable
   );
 
@@ -351,7 +310,7 @@ void scene_gameplay_populate(
   );
 
   player_data->renderables = (
-    scene->renderables + 2
+    scene->renderables + 6
   );
 }
 
@@ -408,7 +367,6 @@ void scene_gameplay_poll(
 
   object = (
     scene->renderables[
-      scene->length_renderables -
       1
     ].renderable
   );
@@ -436,7 +394,6 @@ void scene_gameplay_poll(
 
   object = (
     scene->renderables[
-      scene->length_renderables -
       2
     ].renderable
   );
@@ -451,7 +408,6 @@ void scene_gameplay_poll(
 
   object = (
     scene->renderables[
-      scene->length_renderables -
       3
     ].renderable
   );

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -258,7 +258,7 @@ void scene_gameplay_populate(
     ) {
       scene->renderables = realloc(
         scene->renderables,
-        sizeof(struct metil_object*) *
+        sizeof(struct metil_renderable*) *
         length_renderables
       );
     }
@@ -268,7 +268,7 @@ void scene_gameplay_populate(
     ) {
       scene->renderables = realloc(
         scene->renderables,
-        sizeof(struct metil_object*) *
+        sizeof(struct metil_renderable*) *
         length_renderables
       );
     }

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -14,6 +14,7 @@
 #include <metil_debug/log.h>
 #include <metil_object.h>
 #include <metil_paths/paths.h>
+#include <metil_positioning.h>
 #include <metil_rendering/metil_renderer_data_object.h>
 #include <metil_scenes/scene.h>
 
@@ -78,25 +79,8 @@ void scene_gameplay_initialize(
       index_renderable
     ].renderable;
 
-    if (
-      index_renderable != scene->length_renderables - 4
-    ) {
-      object->index_pipeline_render = (
-        c938_pipeline_index_hud_item
-      );
-    }
-  }
 
-  object = (
-    scene->renderables[
-      scene->length_renderables - 4
-    ].renderable
-  );
-
-  object_crosshair_initialize(
-    object,
-    scene->metal_device
-  );
+    object->positioning = metil_positioning_static;
 
   scene->length_textures = 1;
   scene->textures = realloc(
@@ -122,6 +106,8 @@ void scene_gameplay_initialize(
   mesh_player_initialize(
     &object->mesh
   );
+
+  object->positioning = metil_positioning_player;
 
   metil_object_buffers_initialize(
     object,

--- a/sources/scenes/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main.m
@@ -14,6 +14,7 @@
 #include <metil_mesh/mesh_text.h>
 #include <metil_object.h>
 #include <metil_paths/paths.h>
+#include <metil_positioning.h>
 #include <metil_rendering/metil_renderer_data_object.h>
 #include <metil_rendering/metil_renderer_data_menu_item.h>
 #include <metil_scenes/scene.h>
@@ -117,6 +118,8 @@ void scene_menu_main_initialize(
     &metil_text_render_parameters_default
   );
 
+  object->positioning = metil_positioning_static;
+
   metil_object_buffers_initialize_with_data_size(
     object,
     metal_device,
@@ -169,6 +172,8 @@ void scene_menu_main_initialize(
     &metil_text_render_parameters_default
   );
 
+  object->positioning = metil_positioning_static;
+
   metil_object_buffers_initialize(
     object,
     metal_device
@@ -213,6 +218,8 @@ void scene_menu_main_initialize(
     "exit",
     &metil_text_render_parameters_default
   );
+
+  object->positioning = metil_positioning_static;
 
   metil_object_buffers_initialize(
     object,


### PR DESCRIPTION
- fix library locations
- fix target building coloring: BLUE
- relayout allocations of gameplay renderables
- fix reallocation of `metil_object` instead of reallocating `metil_renderables`
- `metil_mesh_positioning_%`->`metil_positioning_%`