### PR TITLE
[enh] Metil 1 0 0 compatibility default brightness

### DIFF
--- a/sources/c938.m
+++ b/sources/c938.m
@@ -25,6 +25,9 @@ int main(
   const char** parameters
   #endif
 ) {
+  metil_configuration_default_rendering_properties_brightness = 0.05f;
+  metil_configuration_default_rendering_properties_brightness_text = 0.5f;
+
   metil_player_speed_movement_default = player_speed_movement_default;
 
   #if target_os_ios


### PR DESCRIPTION
- `c938`
- - set:`metil_configuration_default_rendering_properties_brightness`
- - set:`metil_configuration_default_rendering_properties_brightness_text`