### PR TITLE
[dev|enh] initial sound generation for projectiles

### DIFF
--- a/include/data/scene_gameplay_data.h
+++ b/include/data/scene_gameplay_data.h
@@ -1,0 +1,14 @@
+#ifndef __scene_gameplay_data_h
+#define __scene_gameplay_data_h
+
+#include <metil_menus/metil_menu.h>
+
+struct scene_gameplay_data {
+  struct metil_menu menu;
+  unsigned char visible_menu;
+
+  unsigned long int* _Nonnull fired_projectiles;
+  unsigned int length_projectiles;
+};
+
+#endif

--- a/include/data/scene_gameplay_data.h
+++ b/include/data/scene_gameplay_data.h
@@ -3,11 +3,15 @@
 
 #include <metil_menus/metil_menu.h>
 
+#define scene_gameplay_data_length_projectiles_maximum 200
+
 struct scene_gameplay_data {
   struct metil_menu menu;
   unsigned char visible_menu;
 
-  unsigned long int* _Nonnull fired_projectiles;
+  unsigned long int fired_projectiles[
+    scene_gameplay_data_length_projectiles_maximum
+  ];
   unsigned int length_projectiles;
 };
 

--- a/include/scenes/scene_gameplay.h
+++ b/include/scenes/scene_gameplay.h
@@ -6,7 +6,9 @@
 #include <metil.h>
 #include <metil_scenes/metil_scene.h>
 
-#if !target_os_ios
+#if target_os_ios
+#include <AVFAudio/AVFAudio.h>
+#else
 #include <CoreAudio/CoreAudio.h>
 #endif
 
@@ -68,7 +70,15 @@ float scene_gameplay_io_proc_value_get(
   unsigned long int
 );
 
-#if !target_os_ios
+#if target_os_ios
+int scene_gameplay_io_proc(
+  unsigned char,
+  const AudioTimeStamp* _Nonnull,
+  unsigned int,
+  AudioBufferList* _Nonnull,
+  void* _Nonnull
+);
+#else
 OSStatus scene_gameplay_io_proc(
   AudioObjectID,
   const AudioTimeStamp* _Nonnull,

--- a/include/scenes/scene_gameplay.h
+++ b/include/scenes/scene_gameplay.h
@@ -1,9 +1,9 @@
 #ifndef __scenes_scene_gameplay_h
 #define __scenes_scene_gameplay_h
 
+#include <data/scene_gameplay_data.h>
+
 #include <metil.h>
-#include <metil_menus/metil_menu.h>
-#include <metil_rendering/metil_renderer_interface.h>
 #include <metil_scenes/metil_scene.h>
 
 #if !target_os_ios
@@ -40,11 +40,6 @@ enum scene_gameplay_textures {
   scene_gameplay_textures_index_buildings = 0
 };
 
-struct scene_gameplay_data {
-  struct metil_menu menu;
-  unsigned char visible_menu;
-};
-
 void scene_gameplay_initialize(
   struct metil* _Nonnull,
   struct metil_scene* _Nonnull
@@ -64,6 +59,13 @@ void scene_gameplay_poll(
 void scene_gameplay_destroy(
   struct metil* _Nonnull,
   struct metil_scene* _Nonnull
+);
+
+float scene_gameplay_io_proc_value_get(
+  struct scene_gameplay_data* _Nonnull,
+  unsigned long int,
+  unsigned long int,
+  unsigned long int
 );
 
 #if !target_os_ios

--- a/include/scenes/scene_menu_main.h
+++ b/include/scenes/scene_menu_main.h
@@ -6,7 +6,9 @@
 #include <metil_rendering/metil_renderer_interface.h>
 #include <metil_scenes/metil_scene.h>
 
-#if !target_os_ios
+#if target_os_ios
+#include <AVFAudio/AVFAudio.h>
+#else
 #include <CoreAudio/CoreAudio.h>
 #endif
 
@@ -53,7 +55,15 @@ void scene_menu_main_destroy(
   struct metil_scene* _Nonnull
 );
 
-#if !target_os_ios
+#if target_os_ios
+int scene_menu_main_io_proc(
+  unsigned char,
+  const AudioTimeStamp* _Nonnull,
+  unsigned int,
+  AudioBufferList* _Nonnull,
+  void* _Nonnull
+);
+#else
 OSStatus scene_menu_main_io_proc(
   AudioObjectID,
   const AudioTimeStamp* _Nonnull,

--- a/sources/player.m
+++ b/sources/player.m
@@ -649,17 +649,30 @@ void player_poll(
       metil_scene_gameplay->data
     );
 
-    scene_gameplay_data->length_projectiles = (
-      scene_gameplay_data->length_projectiles +
-      1
-    );
-
-    scene_gameplay_data->fired_projectiles = realloc(
-      scene_gameplay_data->fired_projectiles,
-      sizeof(unsigned long int) *
-      scene_gameplay_data->length_projectiles
-    );
-
+    if (
+      scene_gameplay_data->length_projectiles == scene_gameplay_data_length_projectiles_maximum
+    ) {
+      for (
+        unsigned int index_projectile_shift = 0;
+        index_projectile_shift < scene_gameplay_data->length_projectiles - 1;
+        ++index_projectile_shift
+      ) {
+        scene_gameplay_data->fired_projectiles[
+          index_projectile_shift
+        ] = (
+          scene_gameplay_data->fired_projectiles[
+            index_projectile_shift +
+            1
+          ]
+        );
+      }
+    } else {
+      scene_gameplay_data->length_projectiles = (
+        scene_gameplay_data->length_projectiles +
+        1
+      );
+    }
+    
     scene_gameplay_data->fired_projectiles[
       scene_gameplay_data->length_projectiles -
       1

--- a/sources/player.m
+++ b/sources/player.m
@@ -2,12 +2,15 @@
 
 #include <objects/object_projectile.h>
 #include <data/player_data.h>
+#include <data/scene_gameplay_data.h>
 
 #include <metil_group.h>
 #include <metil_input/metil_keycodes.h>
 #include <metil_input/metil_input_map.h>
 #include <metil_object.h>
 #include <metil_player/metil_player.h>
+#include <metil_scenes/metil_scene.h>
+#include <metil_scenes/metil_scene_controller.h>
 
 #include <math.h>
 #include <stdlib.h>
@@ -632,6 +635,36 @@ void player_poll(
     metil_group_add_initialize(
       player_data->projectiles,
       metil_renderable_type_object
+    );
+
+    struct metil_scene_controller* metil_scene_controller = (
+      metil->scene_controller
+    );
+
+    struct metil_scene* metil_scene_gameplay = &(
+      metil_scene_controller->scene
+    );
+
+    struct scene_gameplay_data* scene_gameplay_data = (
+      metil_scene_gameplay->data
+    );
+
+    scene_gameplay_data->length_projectiles = (
+      scene_gameplay_data->length_projectiles +
+      1
+    );
+
+    scene_gameplay_data->fired_projectiles = realloc(
+      scene_gameplay_data->fired_projectiles,
+      sizeof(unsigned long int) *
+      scene_gameplay_data->length_projectiles
+    );
+
+    scene_gameplay_data->fired_projectiles[
+      scene_gameplay_data->length_projectiles -
+      1
+    ] = (
+      *player_data->time
     );
 
     struct metil_renderable* metil_renderable_projectile = (

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -35,6 +35,12 @@
 #include <rand_source.h>
 #include <rand_source_type.h>
 
+#if !target_os_ios
+#include <CoreAudio/CoreAudio.h>
+#else
+#include <UIKit/UIKit.h>
+#endif
+
 #include <stdlib.h>
 
 void scene_gameplay_initialize(
@@ -75,13 +81,6 @@ void scene_gameplay_initialize(
       0
     );
   }
-
-  #if !target_os_ios
-  metil_audio_io_proc_add(
-    &metil->audio,
-    scene_gameplay_io_proc
-  );
-  #endif
 
   scene->player.poll = player_poll;
   scene->player.poll_input = player_poll_input;
@@ -274,6 +273,11 @@ void scene_gameplay_initialize(
     metil,
     scene,
     scene_gameplay_length_buildings_default
+  );
+
+  metil_audio_io_proc_add(
+    &metil->audio,
+    scene_gameplay_io_proc
   );
 }
 
@@ -811,12 +815,10 @@ void scene_gameplay_destroy(
   struct metil* metil,
   struct metil_scene* scene
 ) {
-  #if !target_os_ios
   metil_audio_io_proc_remove(
     &metil->audio,
     scene_gameplay_io_proc
   );
-  #endif
 
   free(
     scene->data
@@ -892,10 +894,6 @@ float scene_gameplay_io_proc_value_get(
       ) / (((float) d) / 2.0f) - 1.0f) * 0.5f;
     }
 
-    if (frame % 2 == 0) {
-      a = -a;
-    }
-
     if (
       v % 2 == 0
     ) {
@@ -938,7 +936,65 @@ float scene_gameplay_io_proc_value_get(
   return value;
 }
 
-#if !target_os_ios
+
+#if target_os_ios
+int scene_gameplay_io_proc(
+  unsigned char silence,
+  const AudioTimeStamp* _Nonnull timestamp,
+  AVAudioFrameCount frame_count,
+  AudioBufferList* _Nonnull output_data,
+  void* data
+) {
+  struct metil_audio_io_proc_data* metil_audio_io_proc_data = (
+    data
+  );
+
+  struct metil* metil = (
+    metil_audio_io_proc_data->metil
+  );
+
+  struct metil_scene_controller* metil_scene_controller = (
+    metil->scene_controller
+  );
+
+  struct metil_scene* metil_scene_gameplay = &(
+    metil_scene_controller->scene
+  );
+
+  struct scene_gameplay_data* scene_gameplay_data = (
+    metil_scene_gameplay->data
+  );
+
+  for (
+    unsigned int index_frame = 0;
+    index_frame < frame_count;
+    ++index_frame
+  ) {
+    for (
+      unsigned long int index_buffer = 0;
+      index_buffer < output_data->mNumberBuffers;
+      ++index_buffer
+    ) {
+      AudioBuffer audio_buffer_current = output_data->mBuffers[
+        index_buffer
+      ];
+
+      float* buffer_out = audio_buffer_current.mData;
+
+      buffer_out[
+        index_frame
+      ] = scene_gameplay_io_proc_value_get(
+        scene_gameplay_data,
+        metil_scene_gameplay->time,
+        index_buffer,
+        index_frame
+      );
+    }
+  }
+  
+  return 0;
+}
+#else
 OSStatus scene_gameplay_io_proc(
   AudioObjectID id_audio_object,
   const AudioTimeStamp* time_stamp_audio,

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -63,10 +63,18 @@ void scene_gameplay_initialize(
   );
 
   scene_gameplay_data->length_projectiles = 0;
-  scene_gameplay_data->fired_projectiles = malloc(
-    sizeof(unsigned long int) *
-    scene_gameplay_data->length_projectiles
-  );
+
+  for (
+    unsigned char index_projectile = 0;
+    index_projectile < scene_gameplay_data_length_projectiles_maximum;
+    ++index_projectile
+  ) {
+    scene_gameplay_data->fired_projectiles[
+      index_projectile
+    ] = (
+      0
+    );
+  }
 
   #if !target_os_ios
   metil_audio_io_proc_add(
@@ -286,8 +294,12 @@ void scene_gameplay_populate(
   scene->player.velocity.y = 0.0f;
   scene->player.velocity.z = 0.0f;
 
+  struct scene_gameplay_data* scene_gameplay_data = (
+    scene->data
+  );
+
   struct player_data* player_data = (
-    (struct player_data*) scene->player.data
+    scene->player.data
   );
 
   player_data_initialize(
@@ -296,6 +308,20 @@ void scene_gameplay_populate(
   );
 
   player_data->time = &scene->time;
+
+  scene_gameplay_data->length_projectiles = 0;
+
+  for (
+    unsigned char index_projectile = 0;
+    index_projectile < scene_gameplay_data_length_projectiles_maximum;
+    ++index_projectile
+  ) {
+    scene_gameplay_data->fired_projectiles[
+      index_projectile
+    ] = (
+      0
+    );
+  }
 
   struct metil_group* metil_group_buildings = (
     scene->renderables[
@@ -792,14 +818,6 @@ void scene_gameplay_destroy(
   );
   #endif
 
-  struct scene_gameplay_data* scene_gameplay_data = (
-    scene->data
-  );
-
-  free(
-    scene_gameplay_data->fired_projectiles
-  );
-
   free(
     scene->data
   );
@@ -861,13 +879,6 @@ float scene_gameplay_io_proc_value_get(
           );
         }
 
-        // no need to reallocate here as it will be reallocated when another projectile is fired
-        // saves a call to realloc and since the values are shifted they remain aligned to the length
-        // reallocation within the main thread _may_ cause issues with memory addressing but seems to
-        // work fine currently. one potential solution is to allocate an array of X length during initialization
-        // and only allow X number of sounds at a single time. then the array would never need to be reallocated,
-        // would have the same memory address and prevent too many projectile noises leading to muddiness.
-        // to be determined at a later date and time.
         scene_gameplay_data->length_projectiles = (
           scene_gameplay_data->length_projectiles -
           1

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -1,5 +1,9 @@
 #include <scenes/scene_gameplay.h>
 
+#include <data/enemy_data.h>
+#include <data/player_data.h>
+#include <data/projectile_data.h>
+#include <data/scene_gameplay_data.h>
 #include <generate/generate_buildings.h>
 #include <mesh/mesh_hud_item.h>
 #include <mesh/mesh_player.h>
@@ -13,6 +17,7 @@
 
 #include <metil.h>
 #include <metil_audio/metil_audio_io_proc.h>
+#include <metil_audio/metil_audio_io_proc_data.h>
 #include <metil_debug/metil_debug_log.h>
 #include <metil_group.h>
 #include <metil_object.h>
@@ -21,6 +26,7 @@
 #include <metil_rendering/metil_renderer_data_object.h>
 #include <metil_rendering/metil_renderer_interface.h>
 #include <metil_scenes/metil_scene.h>
+#include <metil_scenes/metil_scene_controller.h>
 
 #include <rand_functions.h>
 #include <rand_initialize.h>
@@ -46,6 +52,20 @@ void scene_gameplay_initialize(
     metil,
     scene,
     scene_gameplay_length_renderables
+  );
+
+  scene->data = malloc(
+    sizeof(struct scene_gameplay_data)
+  );
+
+  struct scene_gameplay_data* scene_gameplay_data = (
+    scene->data
+  );
+
+  scene_gameplay_data->length_projectiles = 0;
+  scene_gameplay_data->fired_projectiles = malloc(
+    sizeof(unsigned long int) *
+    scene_gameplay_data->length_projectiles
   );
 
   #if !target_os_ios
@@ -772,10 +792,139 @@ void scene_gameplay_destroy(
   );
   #endif
 
+  struct scene_gameplay_data* scene_gameplay_data = (
+    scene->data
+  );
+
+  free(
+    scene_gameplay_data->fired_projectiles
+  );
+
+  free(
+    scene->data
+  );
+
+  scene->data = (
+    (void*) 0
+  );
+
   metil_scene_destroy_default(
     metil,
     scene
   );
+}
+
+
+unsigned int b = 100;
+unsigned int d = 1000;
+
+float scene_gameplay_io_proc_value_get(
+  struct scene_gameplay_data* scene_gameplay_data,
+  unsigned long int time_current,
+  unsigned long int channel,
+  unsigned long int frame
+) {
+  float value = 0.0f;
+
+  for (
+    unsigned int index_projectile = 0;
+    index_projectile < scene_gameplay_data->length_projectiles;
+  ) {
+    unsigned long int time_fired = (
+      scene_gameplay_data->fired_projectiles[
+        index_projectile
+      ]
+    );
+
+    unsigned long int v = time_current - time_fired;
+
+    float a = 0.0f;
+    
+    if (v <= b) {
+      a = (float) (
+        b - v
+      ) / (((float) b) / 2.0f) - 1.0f;
+    } else {
+      if (v > d) {
+        for (
+          unsigned int index_projectile_shift = index_projectile;
+          index_projectile_shift < scene_gameplay_data->length_projectiles - 1;
+          ++index_projectile_shift
+        ) {
+          scene_gameplay_data->fired_projectiles[
+            index_projectile_shift
+          ] = (
+            scene_gameplay_data->fired_projectiles[
+              index_projectile_shift +
+              1
+            ]
+          );
+        }
+
+        // no need to reallocate here as it will be reallocated when another projectile is fired
+        // saves a call to realloc and since the values are shifted they remain aligned to the length
+        // reallocation within the main thread _may_ cause issues with memory addressing but seems to
+        // work fine currently. one potential solution is to allocate an array of X length during initialization
+        // and only allow X number of sounds at a single time. then the array would never need to be reallocated,
+        // would have the same memory address and prevent too many projectile noises leading to muddiness.
+        // to be determined at a later date and time.
+        scene_gameplay_data->length_projectiles = (
+          scene_gameplay_data->length_projectiles -
+          1
+        );
+
+        continue;
+      }
+
+      a = ((float) (
+        d - v
+      ) / (((float) d) / 2.0f) - 1.0f) * 0.5f;
+    }
+
+    if (frame % 2 == 0) {
+      a = -a;
+    }
+
+    if (
+      v % 2 == 0
+    ) {
+      a = -a;
+    }
+
+    value = (
+      value +
+      a
+    );
+
+    index_projectile = (
+      index_projectile +
+      1
+    );
+  }
+
+  if (value > 1.0f) {
+    value = (
+      value - (
+        (float) (
+          (unsigned long int) value
+        )
+      )
+    );
+  } else if (value < -1.0f) {
+    value = (
+      value + (
+        (float) (
+          (unsigned long int) (-value)
+        )
+      )
+    );
+  }
+
+  value = (
+    value
+  );
+
+  return value;
 }
 
 #if !target_os_ios
@@ -788,6 +937,26 @@ OSStatus scene_gameplay_io_proc(
   const AudioTimeStamp* time_stamp_audio_out,
   void* data
 ) {
+  struct metil_audio_io_proc_data* metil_audio_io_proc_data = (
+    data
+  );
+
+  struct metil* metil = (
+    metil_audio_io_proc_data->metil
+  );
+
+  struct metil_scene_controller* metil_scene_controller = (
+    metil->scene_controller
+  );
+
+  struct metil_scene* metil_scene_gameplay = &(
+    metil_scene_controller->scene
+  );
+
+  struct scene_gameplay_data* scene_gameplay_data = (
+    metil_scene_gameplay->data
+  );
+
   for (
     unsigned long int index_buffer = 0;
     index_buffer < list_buffer_audio_out->mNumberBuffers;
@@ -820,20 +989,16 @@ OSStatus scene_gameplay_io_proc(
         count_channel_out
       );
 
-      if (
-        channel == 0
-      ) {
-        buffer_out[
+      buffer_out[
+        index_buffer_out
+      ] = (
+        scene_gameplay_io_proc_value_get(
+          scene_gameplay_data,
+          metil_scene_gameplay->time,
+          channel,
           index_buffer_out
-        ] = 0.0f;
-      } else {
-        buffer_out[
-          index_buffer_out
-        ] = buffer_out[
-          index_buffer_out -
-          channel
-        ];
-      }
+        )
+      );
     }
   }
 

--- a/sources/scenes/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main.m
@@ -7,6 +7,7 @@
 #include <textures/textures_buildings.h>
 
 #include <metil_audio/metil_audio_io_proc.h>
+#include <metil_audio/metil_audio_io_proc_data.h>
 #include <metil_debug/metil_debug_log.h>
 #include <metil_group.h>
 #include <metil_input/metil_keycodes.h>
@@ -27,6 +28,7 @@
 #include <AppKit/AppKit.h>
 #include <CoreAudio/CoreAudio.h>
 #else
+#include <AVFAudio/AVFAudio.h>
 #include <UIKit/UIKit.h>
 #endif
 
@@ -34,13 +36,6 @@ void scene_menu_main_initialize(
   struct metil* metil,
   struct metil_scene* scene
 ) {
-  #if !target_os_ios
-  metil_audio_io_proc_add(
-    &metil->audio,
-    scene_menu_main_io_proc
-  );
-  #endif
-
   metil_scene_initialize_with_renderables(
     metil,
     scene,
@@ -268,6 +263,11 @@ void scene_menu_main_initialize(
   );
 
   scene->player.rotation.x = -0.3f;
+
+  metil_audio_io_proc_add(
+    &metil->audio,
+    scene_menu_main_io_proc
+  );
 }
 
 void scene_menu_main_poll(
@@ -436,12 +436,10 @@ void scene_menu_main_destroy(
   struct metil* metil,
   struct metil_scene* scene
 ) {
-  #if !target_os_ios
   metil_audio_io_proc_remove(
     &metil->audio,
     scene_menu_main_io_proc
   );
-  #endif
 
   metil_menu_destroy(
     &(
@@ -455,7 +453,61 @@ void scene_menu_main_destroy(
   );
 }
 
-#if !target_os_ios
+#if target_os_ios
+int scene_menu_main_io_proc(
+  unsigned char silence,
+  const AudioTimeStamp* _Nonnull timestamp,
+  AVAudioFrameCount frame_count,
+  AudioBufferList* _Nonnull output_data,
+  void* data
+) {
+  struct metil_audio_io_proc_data* metil_audio_io_proc_data = (
+    data
+  );
+
+  struct metil* metil = (
+    metil_audio_io_proc_data->metil
+  );
+
+  struct metil_scene_controller* metil_scene_controller = (
+    metil->scene_controller
+  );
+
+  struct metil_scene* metil_scene_gameplay = &(
+    metil_scene_controller->scene
+  );
+
+  struct scene_gameplay_data* scene_gameplay_data = (
+    metil_scene_gameplay->data
+  );
+
+  for (
+    unsigned int index_frame = 0;
+    index_frame < frame_count;
+    ++index_frame
+  ) {
+    for (
+      unsigned long int index_buffer = 0;
+      index_buffer < output_data->mNumberBuffers;
+      ++index_buffer
+    ) {
+      AudioBuffer audio_buffer_current = output_data->mBuffers[
+        index_buffer
+      ];
+
+      float* buffer_out = audio_buffer_current.mData;
+
+      buffer_out[
+        index_frame
+      ] = (
+        0.0f
+      );
+    }
+  }
+  
+  return 0;
+}
+#else
 OSStatus scene_menu_main_io_proc(
   AudioObjectID id_audio_object,
   const AudioTimeStamp* time_stamp_audio,
@@ -495,20 +547,11 @@ OSStatus scene_menu_main_io_proc(
         count_channel_out
       );
 
-      if (
-        index_buffer == 0
-      ) {
-        buffer_out[
-          index_buffer_out
-        ] = 0.0f;
-      } else {
-        buffer_out[
-          index_buffer_out
-        ] = buffer_out[
-          index_buffer_out -
-          channel
-        ];
-      }
+      buffer_out[
+        index_buffer_out
+      ] = (
+        0.0f
+      );
     }
   }
 


### PR DESCRIPTION
generates preliminary audio for projectiles fired
utilizes a fixed array of 200 stored within scene data
projectile sounds are added when projectiles are fired removing the oldest sounds if limit maximum is reached
projectile sounds are removed after a life span of 1 second
all projectile sounds are cleared during regeneration/repopulation