### PR TITLE
[enh] Building generation sanity

### DIFF
--- a/include/data/player_data.h
+++ b/include/data/player_data.h
@@ -23,7 +23,8 @@ struct player_data {
   unsigned char is_jumping;
   unsigned char is_jumping_secondary;
 
-  unsigned int on_ground;
+  unsigned short int on_ground;
+  unsigned short int index_target_building;
 
   unsigned char shooting;
 

--- a/include/generate/generate_buildings.h
+++ b/include/generate/generate_buildings.h
@@ -13,6 +13,7 @@ void generate_buildings(
   _Nonnull id<MTLDevice>,
   struct metil_group* _Nonnull,
   unsigned short int,
+  unsigned short int,
   _Nonnull id<MTLTexture>
 );
 

--- a/include/mesh/mesh_building.h
+++ b/include/mesh/mesh_building.h
@@ -10,4 +10,9 @@ void mesh_building_initialize(
   float
 );
 
+void mesh_building_height_set(
+  struct metil_mesh*,
+  float
+);
+
 #endif

--- a/sources/generate/generate_buildings.m
+++ b/sources/generate/generate_buildings.m
@@ -7,6 +7,9 @@
 #include <metil_rendering/metil_renderable.h>
 #include <metil_rendering/metil_renderer_data_object.h>
 
+#include <math_c_absolute.h>
+#include <math_c_maximum.h>
+
 #include <rand_clean.h>
 #include <rand_functions.h>
 #include <rand_initialize.h>
@@ -26,8 +29,6 @@ void generate_buildings(
   unsigned short int index_target_building,
   id<MTLTexture> texture
 ) {
-  signed int size = 2500;
-
   struct metil_object* object = (void*) 0;
   struct metil_object* object_starting_point = (void*) 0;
 
@@ -59,40 +60,12 @@ void generate_buildings(
     );
   }
 
-  object = (
-    metil_group_buildings->renderables[
-      0
-    ]->renderable
-  );
+  struct clic3_vector2_float size_maximum = {
+    .x = 0.0f,
+    .y = 0.0f
+  };
 
-  mesh_building_initialize(
-    &object->mesh,
-    size * 2,
-    1.0f,
-    size * 2
-  );
-
-  object->index_pipeline_render = (
-    c938_pipeline_index_ground
-  );
-
-  object->position.y = 0.0f;
-
-  metil_object_buffers_initialize(
-    object,
-    metal_device
-  );
-
-  metil_object_texture_add(
-    object,
-    texture
-  );
-
-  struct metil_renderer_data_object* data = (
-    object->buffers_vertex[
-      metil_object_buffer_default_index_data
-    ].buffer.contents
-  );
+  struct metil_renderer_data_object* data;
 
   struct rand_parameters rand_parameters;
   struct rand_source rand_source;
@@ -299,7 +272,89 @@ void generate_buildings(
       data->color.z = 1.0f;
       data->color.w = 1.0f;
     }
+
+    struct clic3_vector2_float limits = {
+      .x = (
+        math_c_maximum_float(
+          object->position.x + (
+            object->mesh.size.x /
+            2.0f
+          ),
+          math_c_absolute_float(
+            object->position.x - (
+              object->mesh.size.x /
+              2.0f
+            )
+          )
+        )
+      ),
+      .y = (
+        math_c_maximum_float(
+          object->position.z + (
+            object->mesh.size.z /
+            2.0f
+          ),
+          math_c_absolute_float(
+            object->position.z - (
+              object->mesh.size.z /
+              2.0f
+            )
+          )
+        )
+      )
+    };
+
+    if (
+      limits.x > size_maximum.x
+    ) {
+      size_maximum.x = (
+        limits.x
+      );
+    }
+
+    if (
+      limits.y > size_maximum.y
+    ) {
+      size_maximum.y = (
+        limits.y
+      );
+    } 
   }
+
+  object = (
+    metil_group_buildings->renderables[
+      0
+    ]->renderable
+  );
+
+  mesh_building_initialize(
+    &object->mesh, (
+      size_maximum.x *
+      2.0f +
+      200.0f
+    ),
+    1.0f, (
+      size_maximum.y *
+      2.0f +
+      200.0f
+    )
+  );
+
+  object->index_pipeline_render = (
+    c938_pipeline_index_ground
+  );
+
+  object->position.y = 0.0f;
+
+  metil_object_buffers_initialize(
+    object,
+    metal_device
+  );
+
+  metil_object_texture_add(
+    object,
+    texture
+  );
 
   rand_clean(
     &rand_result,

--- a/sources/generate/generate_buildings.m
+++ b/sources/generate/generate_buildings.m
@@ -7,6 +7,7 @@
 #include <metil_rendering/metil_renderable.h>
 #include <metil_rendering/metil_renderer_data_object.h>
 
+#include <rand_clean.h>
 #include <rand_functions.h>
 #include <rand_initialize.h>
 #include <rand_parameters.h>
@@ -224,4 +225,9 @@ void generate_buildings(
       data->color.w = 1.0f;
     }
   }
+
+  rand_clean(
+    &rand_result,
+    &rand_source
+  );
 }

--- a/sources/generate/generate_buildings.m
+++ b/sources/generate/generate_buildings.m
@@ -23,6 +23,7 @@ void generate_buildings(
   id<MTLDevice> metal_device,
   struct metil_group* metil_group_buildings,
   unsigned short int length_buildings,
+  unsigned short int index_target_building,
   id<MTLTexture> texture
 ) {
   signed int size = 2500;
@@ -101,20 +102,16 @@ void generate_buildings(
     &rand_parameters,
     &rand_result,
     &rand_source,
-    30,
+    6,
     rand_mode_bytes,
     rand_source_type_divisive
   );
-
-  unsigned char offset_index_bytes = 0;
 
   for (
     unsigned char index_building = 1;
     index_building < length_buildings;
     ++index_building
   ) {
-    offset_index_bytes = 0;
-
     rand_get(
       &rand_source,
       &rand_result,
@@ -152,48 +149,126 @@ void generate_buildings(
         index_building
       ]->renderable;
     } else {
-      while (
-        object->position.x - object->mesh.size.x / 2.0f <= object_starting_point->mesh.size.x / 2.0f &&
-        object->position.x + object->mesh.size.x / 2.0f >= -object_starting_point->mesh.size.x / 2.0f &&
-        object->position.z - object->mesh.size.z / 2.0f <= object_starting_point->mesh.size.z / 2.0f &&
-        object->position.z + object->mesh.size.z / 2.0f >= -object_starting_point->mesh.size.z / 2.0f
-      ) {
-        object->position.x = (
-          (size / -2) + ((
-            rand_result.bytes[
-              offset_index_bytes + 10
-            ] *
-            rand_result.bytes[
-              offset_index_bytes + 11
-            ]
-          ) % size)
-        );
-        object->position.z = (
-          (size / -2) + ((
-            rand_result.bytes[
-              offset_index_bytes + 12
-            ] *
-            rand_result.bytes[
-              offset_index_bytes + 13
-            ]
-          ) % size)
+      struct metil_object* metil_object_building_random;
+
+      unsigned char colliding = (
+        0
+      );
+
+      do {
+        rand_get(
+          &rand_source,
+          &rand_result,
+          &rand_parameters
         );
 
-        offset_index_bytes = (
-          offset_index_bytes + 4
+        metil_object_building_random = metil_group_buildings->renderables[
+          (
+            rand_result.bytes[
+              0
+            ] *
+            rand_result.bytes[
+              1
+            ]
+          ) %
+          index_building +
+          1
+        ]->renderable;
+
+        object->position.x = (
+          rand_result.bytes[
+            2
+          ] - (
+            127.5f
+          )
         );
 
         if (
-          offset_index_bytes == 16
+          object->position.x > 0.0f
         ) {
-          offset_index_bytes = 0;
-
-          rand_get(
-            &rand_source,
-            &rand_result,
-            &rand_parameters
+          object->position.x = (
+            object->position.x +
+            metil_object_building_random->position.x +
+            metil_object_building_random->mesh.size.x / 2.0f +
+            object->mesh.size.x / 2.0f
+          );
+        } else {
+          object->position.x = (
+            object->position.x -
+            metil_object_building_random->position.x -
+            metil_object_building_random->mesh.size.x / 2.0f -
+            object->mesh.size.x / 2.0f
           );
         }
+
+        object->position.z = (
+          rand_result.bytes[
+            3
+          ] - (
+            127.5f
+          )
+        );
+
+        if (
+          object->position.z > 0.0f
+        ) {
+          object->position.z = (
+            object->position.z +
+            metil_object_building_random->position.z +
+            metil_object_building_random->mesh.size.z / 2.0f +
+            object->mesh.size.z / 2.0f
+          );
+        } else {
+          object->position.z = (
+            object->position.z -
+            metil_object_building_random->position.z -
+            metil_object_building_random->mesh.size.z / 2.0f -
+            object->mesh.size.z / 2.0f
+          );
+        }
+
+        colliding = 0;
+
+        for (
+          unsigned int index_building_collision = 1;
+          index_building_collision < index_building;
+          ++index_building_collision
+        ) {
+          struct metil_object* metil_object_building_collision_check = (
+             metil_group_buildings->renderables[
+              index_building_collision
+            ]->renderable
+          );
+
+          if (
+            object->position.x - object->mesh.size.x / 2.0f <= metil_object_building_collision_check->position.x + metil_object_building_collision_check->mesh.size.x / 2.0f &&
+            object->position.x + object->mesh.size.x / 2.0f >= metil_object_building_collision_check->position.x - metil_object_building_collision_check->mesh.size.x / 2.0f &&
+            object->position.z - object->mesh.size.z / 2.0f <= metil_object_building_collision_check->position.z + metil_object_building_collision_check->mesh.size.z / 2.0f &&
+            object->position.z + object->mesh.size.z / 2.0f >= metil_object_building_collision_check->position.z - metil_object_building_collision_check->mesh.size.z / 2.0f
+          ) {
+            colliding = 1;
+          }
+        }
+      } while (
+        colliding == 1
+      );
+
+      if (
+        index_building > 1
+      ) {
+        float height = (
+          rand_result.bytes[
+            4
+          ] - (
+            127.5f
+          ) +
+          metil_object_building_random->mesh.size.y
+        );
+
+        mesh_building_height_set(
+          &object->mesh,
+          height
+        );
       }
     }
 
@@ -212,7 +287,7 @@ void generate_buildings(
     ].buffer.contents;
 
     if (
-      index_building == 2
+      index_building == index_target_building
     ) {
       data->color.x = 0.0f;
       data->color.y = 0.0f;

--- a/sources/mesh/mesh_building.c
+++ b/sources/mesh/mesh_building.c
@@ -230,3 +230,62 @@ void mesh_building_initialize(
     mesh->length_vertices - 1
   );
 }
+
+void mesh_building_height_set(
+  struct metil_mesh* metil_mesh,
+  float height
+) {
+  unsigned char layers = 2;
+
+  metil_mesh->size.y = (
+    height
+  );
+
+  for (
+    unsigned short int index_layer = 0;
+    index_layer < layers;
+    ++index_layer
+  ) {
+    unsigned short int index_vertex = (
+      index_layer * 4
+    );
+
+   float position_y = (
+      (
+        (float) index_layer /
+        (float) (
+          layers -
+          1
+        )
+      ) *
+      metil_mesh->size.y
+    );
+
+    metil_mesh->vertices[
+      index_vertex
+    ].y = (
+      position_y
+    );
+
+    metil_mesh->vertices[
+      index_vertex +
+      1
+    ].y = (
+      position_y
+    );
+
+    metil_mesh->vertices[
+      index_vertex +
+      2
+    ].y = (
+      position_y
+    );
+
+    metil_mesh->vertices[
+      index_vertex +
+      3
+    ].y = (
+      position_y
+    );
+  }
+}

--- a/sources/player.m
+++ b/sources/player.m
@@ -12,7 +12,6 @@
 #include <metil_scenes/metil_scene.h>
 #include <metil_scenes/metil_scene_controller.h>
 
-#include <math.h>
 #include <stdlib.h>
 
 const float player_speed_movement_default = 100.0f;

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -28,6 +28,7 @@
 #include <metil_scenes/metil_scene.h>
 #include <metil_scenes/metil_scene_controller.h>
 
+#include <rand_clean.h>
 #include <rand_functions.h>
 #include <rand_initialize.h>
 #include <rand_parameters.h>
@@ -531,6 +532,11 @@ void scene_gameplay_populate(
       speed_enemy
     );
   }
+
+  rand_clean(
+    &rand_result,
+    &rand_source
+  );
 }
 
 void scene_gameplay_poll(

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -1102,7 +1102,7 @@ OSStatus scene_gameplay_io_proc(
           metil_scene_gameplay->time,
           channel,
           index_buffer_out
-        ) * 0.25f
+        )
       );
     }
   }

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -287,6 +287,25 @@ void scene_gameplay_populate(
   struct metil_scene* scene,
   unsigned short int length_buildings
 ) {
+  struct rand_parameters rand_parameters;
+  struct rand_source rand_source;
+  struct rand_result rand_result;
+
+  rand_initialize(
+    &rand_parameters,
+    &rand_result,
+    &rand_source,
+    10,
+    rand_mode_bytes,
+    rand_source_type_divisive
+  );
+
+  rand_get(
+    &rand_source,
+    &rand_result,
+    &rand_parameters
+  );
+
   scene->player.rotation.x = 0.0f;
   scene->player.rotation.y = 0.0f;
   scene->player.rotation.z = 0.0f;
@@ -310,6 +329,18 @@ void scene_gameplay_populate(
   player_data_initialize(
     player_data,
     metil->rendering_properties.camera.height_default
+  );
+
+  player_data->index_target_building = (
+    (
+      rand_result.bytes[0] *
+      rand_result.bytes[1] +
+      rand_result.bytes[2]
+    ) % (
+      length_buildings -
+      2
+    ) +
+    2
   );
 
   player_data->time = &scene->time;
@@ -354,6 +385,7 @@ void scene_gameplay_populate(
     metil->renderer_interface.metal_device,
     metil_group_buildings,
     length_buildings,
+    player_data->index_target_building,
     scene->textures[
       scene_gameplay_textures_index_buildings
     ]
@@ -409,19 +441,6 @@ void scene_gameplay_populate(
 
   metil_group_initialize(
     metil_group_enemies
-  );
-
-  struct rand_parameters rand_parameters;
-  struct rand_source rand_source;
-  struct rand_result rand_result;
-
-  rand_initialize(
-    &rand_parameters,
-    &rand_result,
-    &rand_source,
-    10,
-    rand_mode_bytes,
-    rand_source_type_divisive
   );
 
   float distance_minimum = 200.0f;
@@ -548,7 +567,10 @@ void scene_gameplay_poll(
   );
 
   if (
-    player_data->on_ground == scene_gameplay_group_buildings_index_target
+    player_data->on_ground == (
+      player_data->index_target_building +
+      1
+    )
   ) {
     struct metil_group* metil_group_buildings = (
       scene->renderables[
@@ -1080,7 +1102,7 @@ OSStatus scene_gameplay_io_proc(
           metil_scene_gameplay->time,
           channel,
           index_buffer_out
-        )
+        ) * 0.25f
       );
     }
   }

--- a/sources/scenes/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main.m
@@ -249,6 +249,7 @@ void scene_menu_main_initialize(
       scene_menu_main_renderables_index_buildings
     ].renderable,
     scene_menu_main_length_buildings_default,
+    100,
     scene->textures[
       scene_menu_main_textures_index_buildings
     ]


### PR DESCRIPTION
generates buildings without any collision and ensures that buildings are within an XYZ range of each other.

first building is technically the ground which spans the width and depth of the absolute maximum building position +/- size
second building is the starting platform which is always at `xyz:[0.0f,0.0f,0.0f]`
every building after that picks a random building within the range of the second building and every subsequent building
once it picks a building it generates a random x and z offset and applies that to the selected buildings position with half of its size and with half of the selected buildings size
it then checks whether the building collides with any other building and if so it reselects a new building, regenerates offsets, and tries again
once a position which doesnt collide is found it then recalculates the height of itself using the selected buildings height and applying a randomly generated offset which can be positive or negative

due to these changes this means that every building should have a traversable path without any being unreachable by the player

as a development note, the target building now has an id attached to it rather than always being set as the index of building 2. the target building can be the index of any building that has been generated besides the starting building and the ground

- additional
- - `rand_clean`:add in instances where rand is initialized

<img width="1966" height="1250" alt="Screenshot 2026-01-03 at 23 15 23" src="https://github.com/user-attachments/assets/badbf92c-f384-47a4-9b61-5cd3ad94d8a4" />
<img width="1966" height="1250" alt="Screenshot 2026-01-03 at 23 15 29" src="https://github.com/user-attachments/assets/13c9a467-9943-45d1-a7cb-a31aba0cfd52" />
<img width="1966" height="1250" alt="Screenshot 2026-01-03 at 23 15 45" src="https://github.com/user-attachments/assets/c3af9d4c-d0fe-468d-9927-62a2c661530b" />
<img width="1966" height="1250" alt="Screenshot 2026-01-03 at 23 15 50" src="https://github.com/user-attachments/assets/776b6739-1a20-45e6-abdb-18cc8dd378d4" />
<img width="1966" height="1250" alt="Screenshot 2026-01-03 at 23 16 02" src="https://github.com/user-attachments/assets/f4fcaa8d-ae4f-4f18-8b7f-488db042a3ac" />

