### PR TITLE
[bug] Custom parameters reset for normal start

### DIFF
--- a/sources/scenes/scene_menu_main/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main/scene_menu_main.m
@@ -907,6 +907,11 @@ void scene_menu_main_poll(
             "scene_menu_main:starting\n"
           );
 
+          parameters_gameplay_initialize(
+            data->parameters_gameplay,
+            metil->player_defaults.speed_movement
+          );
+
           data->time_started = (
             scene->time
           );


### PR DESCRIPTION
have to reinitialize the parameters or it would use the custom ones