### PR TITLE
[dev] Sockets::data

### DIFF
--- a/include/c938_logging.h
+++ b/include/c938_logging.h
@@ -1,0 +1,14 @@
+#ifndef __c938_logging_h
+#define __c938_logging_h
+
+#include <metil_group.h>
+
+struct c938_logging {
+  struct metil_group group;
+};
+
+void c938_logging_initialize(
+  struct c938_logging* _Nonnull
+);
+
+#endif

--- a/include/data/c938_data.h
+++ b/include/data/c938_data.h
@@ -1,0 +1,18 @@
+#ifndef __c938_data_h
+#define __c938_data_h
+
+#include <c938_logging.h>
+
+#include <data/parameters_gameplay.h>
+
+struct c938_data {
+  struct c938_logging logging;
+
+  struct parameters_gameplay parameters_gameplay;
+};
+
+void c938_data_initialize(
+  struct c938_data* _Nonnull
+);
+
+#endif

--- a/include/data/parameters_gameplay.h
+++ b/include/data/parameters_gameplay.h
@@ -9,6 +9,12 @@ enum gameplay_objective {
   gameplay_objective_enemies = 1
 };
 
+enum parameters_gameplay_networked {
+  parameters_gameplay_networked_none = 0b0000,
+  parameters_gameplay_networked_host = 0b0001,
+  parameters_gameplay_networked_client = 0b0010
+};
+
 struct parameters_gameplay {
   enum gameplay_objective objective;
 
@@ -20,6 +26,8 @@ struct parameters_gameplay {
   float multiplier_buildings;
   float multiplier_enemies;
   float multiplier_speed_movement;
+
+  unsigned char networked;
 };
 
 void parameters_gameplay_initialize(

--- a/include/scenes/scene_gameplay.h
+++ b/include/scenes/scene_gameplay.h
@@ -43,8 +43,7 @@ enum scene_gameplay_textures {
 
 void scene_gameplay_initialize(
   struct metil* _Nonnull,
-  struct metil_scene* _Nonnull,
-  struct parameters_gameplay* _Nonnull
+  struct metil_scene* _Nonnull
 );
 
 void scene_gameplay_populate(

--- a/include/scenes/scene_menu_main/scene_menu_main.h
+++ b/include/scenes/scene_menu_main/scene_menu_main.h
@@ -21,7 +21,7 @@
 #define scene_menu_main_length_buildings_default 200
 #define scene_menu_main_time_scene_transition 333
 
-#define scene_menu_main_length_renderables 8
+#define scene_menu_main_length_renderables 9
 
 #define scene_menu_main_length_group_renderables_text_main menus_menu_main_length
 #define scene_menu_main_length_group_renderables_text_main_backing scene_menu_main_length_group_renderables_text_main
@@ -40,7 +40,8 @@ enum scene_menu_main_renderables_index {
   scene_menu_main_renderables_index_group_text_menu_custom_backing = 4,
   scene_menu_main_renderables_index_group_text_menu_custom = 5,
   scene_menu_main_renderables_index_group_text_menu_network_backing = 6,
-  scene_menu_main_renderables_index_group_text_menu_network = 7
+  scene_menu_main_renderables_index_group_text_menu_network = 7,
+  scene_menu_main_renderables_index_group_logging = 8
 };
 
 enum scene_menu_main_renderables_group_text_main_index {
@@ -93,8 +94,7 @@ enum scene_menu_main_textures_index {
 
 void scene_menu_main_initialize(
   struct metil* _Nonnull,
-  struct metil_scene* _Nonnull,
-  struct parameters_gameplay* _Nonnull
+  struct metil_scene* _Nonnull
 );
 
 void scene_menu_main_poll(

--- a/sources/c938.m
+++ b/sources/c938.m
@@ -1,12 +1,15 @@
 #include <c938.h>
 
 #include <c938_pipeline_index.h>
+#include <data/c938_data.h>
 #include <data/parameters_gameplay.h>
 #include <data/scene_menu_main_data.h>
 #include <player.h>
 #include <scenes/scene_id.h>
 #include <scenes/scene_menu_main/scene_menu_main.h>
 #include <scenes/scene_gameplay.h>
+
+#include <clic3_memory.h>
 
 #if target_os_ios
 #include <metil_application/metil_application.h>
@@ -21,9 +24,7 @@
 #include <metil_scenes/metil_scene_controller.h>
 
 #if target_os_ios
-char* c938_executable_path = (
-  (void*) 0
-);
+char* c938_executable_path = 0;
 #endif
 
 int main(
@@ -216,46 +217,53 @@ void c938_renderer_on_initialize(
     c938_pipeline_index_text
   );
 
-  static struct parameters_gameplay* parameters_gameplay = (
-    (void*) 0
-  );
-
-  parameters_gameplay = (
-    malloc(
+  metil->data = (
+    clic3_memory_allocate_raw(
       sizeof(
-        struct parameters_gameplay
+        struct c938_data
       )
     )
   );
 
+  struct c938_data* c938_data = (
+    metil->data
+  );
+
+  c938_data_initialize(
+    c938_data
+  );
+
   parameters_gameplay_initialize(
-    parameters_gameplay,
+    &c938_data->parameters_gameplay,
     metil->player_defaults.speed_movement
   );
 
   metil_termination_on_function_add(
     &metil->termination,
     c938_termination,
-    parameters_gameplay
+    c938_data
+  );
+
+  struct metil_scene_controller* metil_scene_controller = (
+    metil->scene_controller
   );
 
   scene_menu_main_initialize(
     metil,
-    &((struct metil_scene_controller*) metil->scene_controller)->scene,
-    parameters_gameplay
+    &metil_scene_controller->scene
   );
 
   metil_scene_controller_on_scene_change_add(
-    metil->scene_controller,
+    metil_scene_controller,
     c938_on_scene_change,
-    parameters_gameplay
+    0
   );
 }
 
 void c938_on_scene_change(
   struct metil* metil,
   int id_scene,
-  void* parameters_gameplay
+  void* data
 ) {
   struct metil_scene_controller* metil_scene_controller = (
     metil->scene_controller
@@ -277,15 +285,13 @@ void c938_on_scene_change(
     case scene_id_menu_main:
       scene_menu_main_initialize(
         metil,
-        metil_scene,
-        parameters_gameplay
+        metil_scene
       );
       break;
     case scene_id_gameplay:
       scene_gameplay_initialize(
         metil,
-        metil_scene,
-        parameters_gameplay
+        metil_scene
       );
       break;
   }
@@ -294,7 +300,11 @@ void c938_on_scene_change(
 void c938_termination(
   void* data
 ) {
-  free(
+  struct c938_data* c938_data = (
     data
+  );
+
+  clic3_memory_free_raw(
+    c938_data
   );
 }

--- a/sources/c938_logging.m
+++ b/sources/c938_logging.m
@@ -1,0 +1,11 @@
+#include <c938_logging.h>
+
+#include <metil_group.h>
+
+void c938_logging_initialize(
+  struct c938_logging* c938_logging
+) {
+  metil_group_initialize(
+    &c938_logging->group
+  );
+}

--- a/sources/data/c938_data.m
+++ b/sources/data/c938_data.m
@@ -1,0 +1,11 @@
+#include <data/c938_data.h>
+
+#include <c938_logging.h>
+
+void c938_data_initialize(
+  struct c938_data* c938_data
+) {
+  c938_logging_initialize(
+    &c938_data->logging
+  );
+}

--- a/sources/data/parameters_gameplay.c
+++ b/sources/data/parameters_gameplay.c
@@ -31,4 +31,8 @@ void parameters_gameplay_initialize(
   parameters_gameplay->multiplier_speed_movement = (
     1.2f
   );
+
+  parameters_gameplay->networked = (
+    parameters_gameplay_networked_none
+  );
 }

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -1,5 +1,6 @@
 #include <scenes/scene_gameplay.h>
 
+#include <data/c938_data.h>
 #include <data/enemy_data.h>
 #include <data/parameters_gameplay.h>
 #include <data/player_data.h>
@@ -47,9 +48,16 @@
 
 void scene_gameplay_initialize(
   struct metil* metil,
-  struct metil_scene* scene,
-  struct parameters_gameplay* parameters_gameplay
+  struct metil_scene* scene
 ) {
+  struct c938_data* c938_data = (
+    metil->data
+  );
+
+  struct parameters_gameplay* parameters_gameplay = (
+    &c938_data->parameters_gameplay  
+  );
+
   metil->rendering_properties.brightness = (
     metil->configuration.rendering_properties.brightness
   );

--- a/sources/scenes/scene_menu_main/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main/scene_menu_main.m
@@ -1176,14 +1176,49 @@ void scene_menu_main_poll(
         menu->index_selected
       ) {
         case menus_menu_main_custom_index_start: {
-          metil_debug_log(
-            metil->configuration.debug_log_level,
-            "scene_menu_main:starting\n"
-          );
+          if (
+            data->parameters_gameplay->networked ==
+            parameters_gameplay_networked_none
+          ) {
+            metil_debug_log(
+              metil->configuration.debug_log_level,
+              "scene_menu_main:starting_custom\n"
+            );
 
-          data->time_started = (
-            scene->time
-          );
+            data->time_started = (
+              scene->time
+            );
+          } else {
+            metil_debug_log(
+              metil->configuration.debug_log_level,
+              "scene_menu_main:starting_network_host\n"
+            );
+
+            unsigned char status_network_host_listen = (
+              network_host_listen(
+                &data->network_host,
+                metil->system_information.cores_cpu
+              )
+            );
+
+            if (
+              status_network_host_listen != 0
+            ) {
+              metil_debug_log(
+                metil->configuration.debug_log_level,
+                "scene_menu_main:network_host:failure_to_start\n"
+              );
+
+              menu->index_selected = -1;
+              menu->handled = 0;
+            } else {
+              metil_scene_controller_scene_change(
+                metil,
+                metil->scene_controller,
+                scene_id_gameplay
+              );
+            }
+          }
 
           break;
         }
@@ -1192,15 +1227,27 @@ void scene_menu_main_poll(
           menu->index_selected = -1;
           menu->handled = 0;
 
-          metil_group_text_main_backing->visible = 1;
-          metil_group_text_main->visible = 1;
-
           metil_group_text_menu_custom_backing->visible = 0;
           metil_group_text_menu_custom->visible = 0;
 
-          data->menu_current = &(
-            data->menu_main
-          );
+          if (
+            data->parameters_gameplay->networked ==
+            parameters_gameplay_networked_none
+          ) {
+            data->menu_current = &(
+              data->menu_main
+            );
+
+            metil_group_text_main_backing->visible = 1;
+            metil_group_text_main->visible = 1;
+          } else {
+            data->menu_current = &(
+              data->menu_main_network
+            );
+
+            metil_group_text_menu_network_backing->visible = 1;
+            metil_group_text_menu_network->visible = 1;
+          }
 
           data->menu_current->index_current = (
             0
@@ -1220,44 +1267,46 @@ void scene_menu_main_poll(
         menu->index_selected
       ) {
         case menus_menu_main_network_index_host: {
-          unsigned char status_network_host_listen = (
-            network_host_listen(
-              &data->network_host,
-              metil->system_information.cores_cpu
-            )
+          data->parameters_gameplay->networked = (
+            parameters_gameplay_networked_host
           );
 
-          if (
-            status_network_host_listen == 0
-          ) {
-            network_host_notification_on_add(
-              &data->network_host,
-              network_host_notification,
-              0
-            );
+          metil_debug_log(
+            metil->configuration.debug_log_level,
+            "setting::parameters_gameplay::networked->{host};\n"
+          );
 
-            network_host_notification_send(
-              &data->network_host,
-              "network_host::online_and_active",
-              network_host_notification_type_default
-            );
-          } else {
-            network_host_notification(
-              "network_host::creation_failed",
-              0,
-              network_host_notification_type_error
-            );
-          }
-
-          menu->index_selected = menus_menu_main_network_index_back;
+          menu->index_selected = -1;
           menu->handled = 0;
+
+          metil_group_text_menu_custom_backing->visible = 1;
+          metil_group_text_menu_custom->visible = 1;
+
+          metil_group_text_menu_network_backing->visible = 0;
+          metil_group_text_menu_network->visible = 0;
+
+          data->menu_current = &(
+            data->menu_main_custom
+          );
+
+          data->menu_current->index_current = (
+            0
+          );
+
+          metil_stopwatch_start(
+            &data->menu_current->stopwatch_input
+          );
 
           break;
         }
         case menus_menu_main_network_index_join: {
+          data->parameters_gameplay->networked = (
+            parameters_gameplay_networked_client
+          );
+          
           metil_debug_log(
             metil->configuration.debug_log_level,
-            "sockets\n"
+            "setting::parameters_gameplay::networked->{client};\n"
           );
 
           menu->index_selected = -1;
@@ -1267,6 +1316,15 @@ void scene_menu_main_poll(
         }
         default:
         case menus_menu_main_network_index_back: {
+          data->parameters_gameplay->networked = (
+            parameters_gameplay_networked_none
+          );
+
+          metil_debug_log(
+            metil->configuration.debug_log_level,
+            "setting::parameters_gameplay::networked->{none};\n"
+          );
+
           menu->index_selected = -1;
           menu->handled = 0;
 

--- a/sources/scenes/scene_menu_main/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main/scene_menu_main.m
@@ -1,6 +1,7 @@
 #include <scenes/scene_menu_main/scene_menu_main.h>
 
 #include <c938_pipeline_index.h>
+#include <data/c938_data.h>
 #include <data/parameters_gameplay.h>
 #include <data/scene_menu_main_data.h>
 #include <generate/generate_buildings.h>
@@ -47,9 +48,16 @@
 
 void scene_menu_main_initialize(
   struct metil* metil,
-  struct metil_scene* scene,
-  struct parameters_gameplay* parameters_gameplay
+  struct metil_scene* scene
 ) {
+  struct c938_data* c938_data = (
+    metil->data
+  );
+
+  struct parameters_gameplay* parameters_gameplay = (
+    &c938_data->parameters_gameplay
+  );
+  
   metil_scene_initialize_with_renderables(
     metil,
     scene,
@@ -76,6 +84,15 @@ void scene_menu_main_initialize(
           index_renderable,
           metil_renderable_type_group
         );
+
+        break;
+      case scene_menu_main_renderables_index_group_logging:
+        scene->renderables[
+          index_renderable
+        ].renderable = (
+          &c938_data->logging.group
+        );
+
         break;
       default:
         metil_renderable_initialize_at_index(
@@ -83,6 +100,7 @@ void scene_menu_main_initialize(
           index_renderable,
           metil_renderable_type_object
         );
+
         break;
     }
   }
@@ -1791,6 +1809,11 @@ void scene_menu_main_destroy(
 
   metil_menu_destroy(
     &scene_menu_main_data->menu_main_custom
+  );
+
+  scene->length_renderables = (
+    scene->length_renderables -
+    1
   );
 
   metil_scene_destroy_default(

--- a/sources/scenes/scene_menu_main/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main/scene_menu_main.m
@@ -1209,9 +1209,27 @@ void scene_menu_main_poll(
                 "scene_menu_main:network_host:failure_to_start\n"
               );
 
+              network_host_notification(
+                "network_host::creation_failed",
+                0,
+                network_host_notification_type_error
+              );
+
               menu->index_selected = -1;
               menu->handled = 0;
             } else {
+              network_host_notification_on_add(
+                &data->network_host,
+                network_host_notification,
+                0
+              );
+
+              network_host_notification_send(
+                &data->network_host,
+                "network_host::online_and_active",
+                network_host_notification_type_default
+              );
+
               metil_scene_controller_scene_change(
                 metil,
                 metil->scene_controller,


### PR DESCRIPTION
- add `c938_data`
- add `c938_logging`
- - this will be used to display application wide notification messages on the screen by preserving a single `metil_group` which then gets set as the last renderable on each scene. during destruction the length of the scene renderables is reduced by `1` to prevent destruction of the group
- add `networked` property to `parameters_gameplay`
- - will be used to determine whether the current game is networked or not and whether the user is a client or a host