### PR TITLE
[dev] sockets:: threaded `network_client`

### DIFF
--- a/include/data/network_data_map.h
+++ b/include/data/network_data_map.h
@@ -14,6 +14,12 @@ void network_data_map_initialize(
   struct network_data_map*
 );
 
+void network_data_map_bytes_set(
+  struct network_data_map*,
+  unsigned char*,
+  unsigned int
+);
+
 void network_data_map_destroy(
   struct network_data_map*
 );

--- a/include/network/network.h
+++ b/include/network/network.h
@@ -6,6 +6,7 @@
 #define network_offset_socket_address_data_ipv4 2
 
 #define c938_network_port 3938
+#define c938_network_data_transfer_limit 50000
 
 enum network_command {
   network_command_initialize = 0x00,

--- a/include/network/network.h
+++ b/include/network/network.h
@@ -7,4 +7,9 @@
 
 #define c938_network_port 3938
 
+enum network_command {
+  network_command_initialize = 0x00,
+  network_command_datamap = 0x01
+};
+
 #endif

--- a/include/network/network_client.h
+++ b/include/network/network_client.h
@@ -1,24 +1,66 @@
 #ifndef __c938_network_network_client_h
 #define __c938_network_network_client_h
 
+#include <data/network_data_map.h>
 #include <network/network.h>
 
 #include <netdb.h>
 #include <netinet/in.h>
+#include <pthread.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
+enum network_client_status {
+  network_client_status_none = 0b0000,
+  network_client_status_quitting = 0b1111,
+  network_client_status_initialized = 0b0001,
+  network_client_status_connected = 0b0010
+};
+
+enum network_client_command_sending {
+  network_client_command_sending_quitting = 0,
+  network_client_command_sending_none = 1
+};
+
 struct network_client {
   int socket;
+
+  unsigned char status;
 
   unsigned char address_ipv4[
     network_length_address_ipv4
   ];
 
   struct sockaddr_in address_host;
+
+  struct network_data_map data_map;
+
+  pthread_t thread_receiving;
+  pthread_t thread_sending;
+
+  pthread_mutex_t mutex;
+  pthread_mutex_t mutex_sending;
+
+  enum network_client_command_sending command_sending;
+};
+
+struct network_client_thread_data {
+  struct network_client* network_client;
 };
 
 unsigned char network_client_connect(
+  struct network_client*
+);
+
+void* network_client_receiving_thread(
+  void*
+);
+
+void* network_client_sending_thread(
+  void*
+);
+
+void network_client_destroy(
   struct network_client*
 );
 

--- a/include/network/network_data_map_functions.h
+++ b/include/network/network_data_map_functions.h
@@ -18,4 +18,14 @@ void network_data_map_set(
   unsigned int
 );
 
+
+void network_data_map_parse(
+  struct network_data_map* _Nonnull,
+  struct parameters_gameplay* _Nonnull,
+  struct metil_group* _Nonnull,
+  struct metil_group* _Nonnull,
+  struct math_c_vector3_float* _Nonnull,
+  unsigned int* _Nonnull
+);
+
 #endif

--- a/sources/data/c938_data.m
+++ b/sources/data/c938_data.m
@@ -1,6 +1,8 @@
 #include <data/c938_data.h>
 
 #include <c938_logging.h>
+#include <network/network_client.h>
+#include <network/network_host.h>
 
 void c938_data_initialize(
   struct c938_data* c938_data
@@ -19,6 +21,10 @@ void c938_data_destroy(
   c938_logging_destroy(
     metil,
     &c938_data->logging
+  );
+
+  network_client_destroy(
+    &c938_data->network_client
   );
 
   network_host_destroy(

--- a/sources/data/network_data_map.c
+++ b/sources/data/network_data_map.c
@@ -1,5 +1,6 @@
 #include <data/network_data_map.h>
 
+#include <clic3_bytes.h>
 #include <clic3_memory.h>
 
 #include <pthread.h>
@@ -18,6 +19,35 @@ void network_data_map_initialize(
   pthread_mutex_init(
     &network_data_map->mutex,
     0
+  );
+}
+
+void network_data_map_bytes_set(
+  struct network_data_map* network_data_map,
+  unsigned char* bytes,
+  unsigned int length
+) {
+  pthread_mutex_lock(
+    &network_data_map->mutex
+  );
+
+  network_data_map->length = (
+    length
+  );
+
+  clic3_memory_reallocate_raw(
+    &network_data_map->bytes,
+    network_data_map->length
+  );
+
+  clic3_bytes_copy(
+    network_data_map->bytes,
+    bytes,
+    network_data_map->length
+  );
+
+  pthread_mutex_unlock(
+    &network_data_map->mutex
   );
 }
 

--- a/sources/network/network_client.c
+++ b/sources/network/network_client.c
@@ -1,9 +1,13 @@
 #include <network/network_client.h>
 
+#include <data/network_data_map.h>
 #include <network/network.h>
+
+#include <clic3_memory.h>
 
 #include <netdb.h>
 #include <netinet/in.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -11,6 +15,14 @@
 unsigned char network_client_connect(
   struct network_client* network_client
 ) {
+  network_client->status = (
+    network_client_status_none
+  );
+
+  network_client->command_sending = (
+    network_client_command_sending_none
+  );
+
   network_client->socket = (
     socket(
       AF_INET,
@@ -75,8 +87,6 @@ unsigned char network_client_connect(
   if (
     status_connect < 0
   ) {
-    printf("failed_to_connect\n");
-
     close(
       network_client->socket
     );
@@ -84,46 +94,242 @@ unsigned char network_client_connect(
     return 2;
   }
 
-  printf("connected\n");
+  network_data_map_initialize(
+    &network_client->data_map
+  );
 
-  char data_host[50000];
+  network_client->status = (
+    network_client->status |
+    network_client_status_initialized |
+    network_client_status_connected
+  );
 
-  long int length_data_received = (
-    recv(
-      network_client->socket,
-      data_host,
-      50000,
-      0
+  static struct network_client_thread_data* network_client_receiving_thread_data;
+  static struct network_client_thread_data* network_client_sending_thread_data;
+
+  network_client_receiving_thread_data = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct network_client_thread_data
+      )
     )
   );
 
-  if (
-    length_data_received > 50000
-  ) {
-    return 3;
-  }
+  network_client_sending_thread_data = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct network_client_thread_data
+      )
+    )
+  );
 
-  for (
-    unsigned short int index_byte = 0;
-    index_byte < length_data_received;
-    ++index_byte
+  network_client_receiving_thread_data->network_client = (
+    network_client
+  );
+
+  network_client_sending_thread_data->network_client = (
+    network_client
+  );
+
+  pthread_mutex_init(
+    &network_client->mutex,
+    0
+  );
+
+  pthread_mutex_init(
+    &network_client->mutex_sending,
+    0
+  );
+
+  pthread_mutex_lock(
+    &network_client->mutex_sending
+  );
+
+  pthread_create(
+    &network_client->thread_receiving,
+    0,
+    network_client_receiving_thread,
+    network_client_receiving_thread_data
+  );
+
+  pthread_create(
+    &network_client->thread_receiving,
+    0,
+    network_client_sending_thread,
+    network_client_sending_thread_data
+  );
+
+  return 0;
+}
+
+void* network_client_receiving_thread(
+  void* data
+) {
+  struct network_client_thread_data* network_client_thread_data = (
+    data
+  );
+
+  struct network_client* network_client = (
+    network_client_thread_data->network_client
+  );
+
+  while (
+    network_client->status != network_client_status_quitting
   ) {
-    printf(
-      "%.2x ",
-      data_host[
-        index_byte
-      ]
+    pthread_mutex_lock(
+      &network_client->mutex
+    );
+
+    unsigned char data_host[
+      c938_network_data_transfer_limit
+    ];
+
+    long int length_data_received = (
+      recv(
+        network_client->socket,
+        data_host,
+        c938_network_data_transfer_limit,
+        0
+      )
+    );
+
+    if (
+      length_data_received > c938_network_data_transfer_limit ||
+      length_data_received < 1
+    ) {
+      return 0;
+    }
+
+    enum network_command network_command = (
+      data_host[0]
+    );
+
+    switch (
+      network_command
+    ) {
+      case network_command_initialize: {
+        break;
+      }
+      case network_command_datamap: {
+        for (
+          unsigned short int index_byte = 0;
+          index_byte < length_data_received;
+          ++index_byte
+        ) {
+          printf(
+          "%.2x ",
+            data_host[
+              index_byte
+            ]
+          );
+        }
+
+        network_data_map_bytes_set(
+          &network_client->data_map,
+          data_host,
+          length_data_received
+        );
+
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+
+    pthread_mutex_unlock(
+      &network_client->mutex
     );
   }
 
-  printf(
-    "\nreceived->{%li::bytes};\n",
-    length_data_received
+  clic3_memory_free(
+    network_client_thread_data
+  );
+
+  return 0;
+}
+
+void* network_client_sending_thread(
+  void* data
+) {
+  struct network_client_thread_data* network_client_thread_data = (
+    data
+  );
+
+  struct network_client* network_client = (
+    network_client_thread_data->network_client
+  );
+
+  unsigned int quitting = 0;
+
+  while (
+    network_client->status != network_client_status_quitting &&
+    quitting == 0
+  ) {
+    pthread_mutex_lock(
+      &network_client->mutex_sending
+    );
+
+    switch (
+      network_client->command_sending
+    ) {
+      case network_client_command_sending_quitting: {
+        quitting = 1;
+
+        break;
+      }
+      case network_client_command_sending_none:
+      default: {
+        break;
+      }
+    }
+  }
+  
+  clic3_memory_free(
+    network_client_thread_data
+  );
+
+  return 0;
+}
+
+void network_client_destroy(
+  struct network_client* network_client
+) {
+  if (
+    network_client->status == network_client_status_none
+  ) {
+    return;
+  }
+
+  network_client->status = network_client_status_quitting;
+
+  pthread_mutex_unlock(
+    &network_client->mutex_sending
   );
 
   close(
     network_client->socket
   );
 
-  return 0;
+  pthread_join(
+    network_client->thread_receiving,
+    0
+  );
+
+  pthread_join(
+    network_client->thread_sending,
+    0
+  );
+
+  pthread_mutex_destroy(
+    &network_client->mutex
+  );
+
+  pthread_mutex_destroy(
+    &network_client->mutex_sending
+  );
+
+  network_data_map_destroy(
+    &network_client->data_map
+  );
 }

--- a/sources/network/network_data_map_functions.m
+++ b/sources/network/network_data_map_functions.m
@@ -218,3 +218,14 @@ void network_data_map_set(
     &network_data_map->mutex
   );
 }
+
+void network_data_map_parse(
+  struct network_data_map* network_data_map,
+  struct parameters_gameplay* parameters_gameplay,
+  struct metil_group* metil_group_buildings,
+  struct metil_group* metil_group_enemies,
+  struct math_c_vector3_float* position_starting,
+  unsigned int* target_building
+) {
+
+}

--- a/sources/network/network_data_map_functions.m
+++ b/sources/network/network_data_map_functions.m
@@ -2,6 +2,7 @@
 
 #include <data/network_data_map.h>
 #include <data/parameters_gameplay.h>
+#include <network/network.h>
 
 #include <clic3_bytes.h>
 #include <clic3_memory.h>
@@ -56,6 +57,7 @@ void network_data_map_set(
   );
 
   network_data_map->length = (
+    1 +
     length_parameters_gameplay +
     length_unsigned_int +
     length_bytes_buildings +
@@ -70,10 +72,17 @@ void network_data_map_set(
     network_data_map->length
   );
 
-  unsigned long int offset_bytes = 0;
+  unsigned long int offset_bytes = 1;
+
+  network_data_map->bytes[0] = (
+    network_command_datamap
+  );
 
   clic3_bytes_copy(
-    network_data_map->bytes,
+    (
+      network_data_map->bytes +
+      offset_bytes
+    ),
     parameters_gameplay,
     length_parameters_gameplay
   );
@@ -84,7 +93,10 @@ void network_data_map_set(
   );
 
   clic3_bytes_copy(
-    network_data_map->bytes,
+    (
+      network_data_map->bytes +
+      offset_bytes
+    ),
     &metil_group_buildings->length,
     length_parameters_gameplay
   );
@@ -135,7 +147,10 @@ void network_data_map_set(
   }
 
   clic3_bytes_copy(
-    network_data_map->bytes,
+    (
+      network_data_map->bytes +
+      offset_bytes
+    ),
     &metil_group_enemies->length,
     length_parameters_gameplay
   );

--- a/sources/network/network_host.c
+++ b/sources/network/network_host.c
@@ -532,7 +532,9 @@ void* network_host_client_receiving_thread(
   while (
     network_host->online
   ) {
-    char data_client[50000];
+    char data_client[
+      c938_network_data_transfer_limit
+    ];
     
     long int length_data_client = (
       recv(
@@ -540,7 +542,7 @@ void* network_host_client_receiving_thread(
           index_client
         ],
         data_client,
-        50000,
+        c938_network_data_transfer_limit,
         0
       )
     );
@@ -598,7 +600,7 @@ void* network_host_client_sending_thread(
           &network_host->data_map.mutex
         );
         
-        long int jdslafkj = (
+        long int length_bytes_sent = (
           send(
             network_host->socket_clients[
               index_client


### PR DESCRIPTION
- `network`
- - add `c938_network_data_transder_limit`
- - add `network_command`
- `network_data_map`:
- - add `network_data_map_bytes_set`
- `network_client`
- - make threaded
- `c938_data`
- - call `network_client_destroy`

threads the `network_client` into two threads, one for receiving data and one for sending data

