### PR TITLE
[bug] Sockets host client connection notification fix

### DIFF
--- a/sources/network/network_host.c
+++ b/sources/network/network_host.c
@@ -310,9 +310,9 @@ void* network_host_routing_thread(
       network_host_notification_type_default
     );
 
-    // clic3_memory_free_raw(
-    //   notification
-    // );
+    clic3_memory_free_raw(
+      notification
+    );
 
     pthread_mutex_lock(
       &network_host->mutex_thread

--- a/sources/network/network_host.c
+++ b/sources/network/network_host.c
@@ -282,10 +282,6 @@ void* network_host_routing_thread(
       );
     }
 
-    char_array_address_client[
-      address_socket_client.sa_len
-    ] = '\0';
-
     char* notification_prefix = (
       clic3_char_arrays_concatenate(
         "network_host::client_connected->{",
@@ -314,9 +310,9 @@ void* network_host_routing_thread(
       network_host_notification_type_default
     );
 
-    clic3_memory_free_raw(
-      notification
-    );
+    // clic3_memory_free_raw(
+    //   notification
+    // );
 
     pthread_mutex_lock(
       &network_host->mutex_thread


### PR DESCRIPTION
fixes access of memory space during client connection

was assigning a null byte to the end of the char array but that index was set to one of the previous iterations length

https://github.com/user-attachments/assets/02bfe3a5-f8ce-43f1-9e38-4f2aa6ea2b22

now host and all connected clients are stable
