### PR TITLE
[dev] sockets :: client data packet sending

### DIFF
--- a/include/network/network_client.h
+++ b/include/network/network_client.h
@@ -4,6 +4,7 @@
 #include <network/data/network_data_map.h>
 #include <network/network.h>
 #include <network/network_client_status.h>
+#include <network/network_client_status_game.h>
 #include <network/network_command.h>
 
 #include <netdb.h>
@@ -16,6 +17,7 @@ struct network_client {
   int socket;
 
   enum network_client_status status;
+  enum network_client_status_game status_game;
 
   unsigned char address_ipv4[
     network_length_address_ipv4

--- a/include/network/network_client.h
+++ b/include/network/network_client.h
@@ -32,8 +32,10 @@ struct network_client {
 
   pthread_mutex_t mutex;
   pthread_mutex_t mutex_sending;
+  pthread_mutex_t mutex_network_data_packets_outgoing;
 
-  enum network_command command_sending;
+  struct network_data_packet** network_data_packets_outgoing;
+  unsigned int length_network_data_packets_outgoing;
 };
 
 struct network_client_thread_data {
@@ -50,6 +52,11 @@ void* network_client_receiving_thread(
 
 void* network_client_sending_thread(
   void*
+);
+
+void network_client_send(
+  struct network_client*,
+  struct network_data_packet*
 );
 
 void network_client_destroy(

--- a/include/network/network_client_status_game.h
+++ b/include/network/network_client_status_game.h
@@ -1,0 +1,11 @@
+#ifndef __network_network_client_status_game_h
+#define __network_network_client_status_game_h
+
+enum network_client_status_game {
+  network_client_status_game_disconnected = 0x00,
+  network_client_status_game_loading = 0x01,
+  network_client_status_game_loaded = 0x02,
+  network_client_status_game_playing = 0x03
+};
+
+#endif

--- a/include/network/network_command.h
+++ b/include/network/network_command.h
@@ -5,7 +5,8 @@ enum network_command {
   network_command_no_operation = 0x00,
   network_command_initialize = 0x01,
   network_command_data_map = 0x02,
-  network_command_disconnecting = 0x03,
+  network_command_data_map_loaded = 0x03,
+  network_command_disconnecting = 0x04,
   network_command_unknown = 0xff
 };
 

--- a/include/network/network_host_client.h
+++ b/include/network/network_host_client.h
@@ -2,6 +2,7 @@
 #define __network_network_host_client_h
 
 #include <network/network_client_status.h>
+#include <network/network_client_status_game.h>
 #include <network/network_command.h>
 
 #include <pthread.h>
@@ -9,17 +10,22 @@
 struct network_host_client {
   int socket;
 
+  unsigned int index;
+  char* char_array_index;
+
   pthread_mutex_t mutex;
   pthread_mutex_t mutex_sending;
 
   enum network_client_status status;
+  enum network_client_status_game status_game;
 
   enum network_command command_sending;
 };
 
 void network_host_client_initialize(
   struct network_host_client*,
-  int
+  int,
+  unsigned int
 );
 
 void network_host_client_destroy(

--- a/sources/network/network_client.c
+++ b/sources/network/network_client.c
@@ -152,8 +152,23 @@ unsigned char network_client_connect(
     0
   );
 
+  pthread_mutex_init(
+    &network_client->mutex_network_data_packets_outgoing,
+    0
+  );
+
   pthread_mutex_lock(
     &network_client->mutex_sending
+  );
+
+  network_client->network_data_packets_outgoing = (
+    clic3_memory_allocate_raw(
+      0
+    )
+  );
+
+  network_client->length_network_data_packets_outgoing = (
+    0
   );
 
   pthread_create(
@@ -242,6 +257,7 @@ void* network_client_receiving_thread(
         break;
       }
       case network_command_initialize:
+      case network_command_no_operation:
       default: {
         clic3_memory_free_raw(
           network_data_packet
@@ -284,22 +300,97 @@ void* network_client_sending_thread(
       &network_client->mutex_sending
     );
 
-    switch (
-      network_client->command_sending
-    ) {
-      case network_command_disconnecting: {
-        network_client->status = (
-          network_client->status |
-          network_client_status_disconnecting
-        );
+    unsigned int index_network_data_packet_outgoing = 0;
 
-        break;
+    for (
+      ;
+      (
+        index_network_data_packet_outgoing <
+        network_client->length_network_data_packets_outgoing
+      );
+      ++index_network_data_packet_outgoing
+    ) {
+      pthread_mutex_lock(
+        &network_client->mutex_network_data_packets_outgoing
+      );
+
+      struct network_data_packet* network_data_packet_outgoing = (
+        network_client->network_data_packets_outgoing[
+          index_network_data_packet_outgoing
+        ]
+      );
+
+      pthread_mutex_unlock(
+        &network_client->mutex_network_data_packets_outgoing
+      );
+
+      switch (
+        network_data_packet_outgoing->command
+      ) {
+        case network_command_data_map_loaded: {
+          network_client->status_game = (
+            network_client_status_game_loaded
+          );
+
+          break;
+        }
+        case network_command_disconnecting: {
+          network_client->status = (
+            network_client->status |
+            network_client_status_disconnecting
+          );
+
+          break;
+        }
+        case network_command_no_operation:
+        default: {
+          break;
+        }
       }
-      case network_command_no_operation:
-      default: {
-        break;
+
+      if (
+        (
+          network_client->status &
+          network_client_status_disconnecting
+        ) == 0
+      ) {
+        network_data_packet_send(
+          network_data_packet_outgoing,
+          network_client->socket
+        );
       }
+
+      network_data_packet_destroy(
+        network_data_packet_outgoing
+      );
+
+      clic3_memory_free_raw(
+        network_data_packet_outgoing
+      );
     }
+
+    pthread_mutex_lock(
+      &network_client->mutex_network_data_packets_outgoing
+    );
+
+    network_client->length_network_data_packets_outgoing = (
+      network_client->length_network_data_packets_outgoing -
+      index_network_data_packet_outgoing
+    );
+
+    clic3_memory_reallocate_raw(
+      &network_client->network_data_packets_outgoing,
+      (
+        sizeof(
+          void*
+        ) *
+        network_client->length_network_data_packets_outgoing
+      )
+    );
+
+    pthread_mutex_unlock(
+      &network_client->mutex_network_data_packets_outgoing
+    );
   }
   
   clic3_memory_free(
@@ -307,6 +398,45 @@ void* network_client_sending_thread(
   );
 
   return 0;
+}
+
+void network_client_send(
+  struct network_client* network_client,
+  struct network_data_packet* network_data_packet
+) {
+  pthread_mutex_lock(
+    &network_client->mutex_network_data_packets_outgoing
+  );
+
+  network_client->length_network_data_packets_outgoing = (
+    network_client->length_network_data_packets_outgoing +
+    1
+  );
+
+  clic3_memory_reallocate_raw(
+    &network_client->network_data_packets_outgoing,
+    (
+      sizeof(
+        void*
+      ) *
+      network_client->length_network_data_packets_outgoing
+    )
+  );
+
+  network_client->network_data_packets_outgoing[
+    network_client->length_network_data_packets_outgoing -
+    1
+  ] = (
+    network_data_packet
+  );
+
+  pthread_mutex_unlock(
+    &network_client->mutex_network_data_packets_outgoing
+  );
+
+  pthread_mutex_unlock(
+    &network_client->mutex_sending
+  );
 }
 
 void network_client_destroy(
@@ -326,6 +456,10 @@ void network_client_destroy(
 
   pthread_mutex_unlock(
     &network_client->mutex_sending
+  );
+
+  pthread_mutex_unlock(
+    &network_client->mutex_network_data_packets_outgoing
   );
 
   close(
@@ -350,7 +484,35 @@ void network_client_destroy(
     &network_client->mutex_sending
   );
 
+  pthread_mutex_destroy(
+    &network_client->mutex_network_data_packets_outgoing
+  );
+
   network_data_map_destroy(
     &network_client->data_map
+  );
+
+  for (
+    unsigned int index_network_data_packet_outgoing = 0;
+    index_network_data_packet_outgoing < network_client->length_network_data_packets_outgoing;
+    ++index_network_data_packet_outgoing
+  ) {
+    struct network_data_packet* network_data_packet_outgoing = (
+      network_client->network_data_packets_outgoing[
+        index_network_data_packet_outgoing
+      ]
+    );
+
+    network_data_packet_destroy(
+      network_data_packet_outgoing
+    );
+
+    clic3_memory_free_raw(
+      network_data_packet_outgoing
+    );
+  }
+
+  clic3_memory_free_raw(
+    network_client->network_data_packets_outgoing
   );
 }

--- a/sources/network/network_client.c
+++ b/sources/network/network_client.c
@@ -19,8 +19,8 @@ unsigned char network_client_connect(
     network_client_status_initializing
   );
 
-  network_client->command_sending = (
-    network_command_no_operation
+  network_client->status_game = (
+    network_client_status_game_loading
   );
 
   network_client->socket = (
@@ -35,7 +35,11 @@ unsigned char network_client_connect(
     network_client->socket < 0
   ) {
     network_client->status = (
-      network_client_status_none
+      network_client_status_disconnected
+    );
+
+    network_client->status_game = (
+      network_client_status_game_disconnected
     );
 
     return 1;
@@ -96,7 +100,7 @@ unsigned char network_client_connect(
     );
 
     network_client->status = (
-      network_client_status_none
+      network_client_status_disconnected
     );
 
     return 2;

--- a/sources/network/network_host.c
+++ b/sources/network/network_host.c
@@ -2,6 +2,9 @@
 
 #include <network/data/network_data_packet.h>
 #include <network/network.h>
+#include <network/network_client_status.h>
+#include <network/network_client_status_game.h>
+#include <network/network_command.h>
 
 #include <clic3_bytes.h>
 #include <clic3_char_arrays.h>
@@ -12,8 +15,6 @@
 #include <pthread.h>
 #include <sys/socket.h>
 #include <unistd.h>
-
-#include <stdio.h>
 
 unsigned char network_host_listen_with_notification(
   struct network_host* network_host,
@@ -385,14 +386,14 @@ void* network_host_routing_thread(
 
     struct network_host_client* network_host_client = &(
       network_host->clients[
-        network_host->length_clients -
-        1
+        network_host_client_receiving_thread_data->index_client
       ]
     );
 
     network_host_client_initialize(
       network_host_client,
-      socket_client
+      socket_client,
+      network_host_client_receiving_thread_data->index_client
     );
 
     pthread_create(
@@ -481,6 +482,54 @@ void* network_host_client_receiving_thread(
       &network_data_packet,
       data_received_client,
       length_data_received_client
+    );
+
+    switch (
+      network_data_packet.command
+    ) {
+      case network_command_data_map_loaded: {
+        network_host_client->status_game = (
+          network_client_status_game_loaded
+        );
+
+        char* notification_prefix = (
+          clic3_char_arrays_concatenate(
+            "network_host_client::load_complete->{",
+            network_host_client->char_array_index
+          )
+        );
+
+        char* notification = (
+          clic3_char_arrays_concatenate(
+            notification_prefix,
+            "};"
+          )
+        );
+
+        notification_manager_send(
+          &network_host->notification_manager,
+          notification,
+          network_host_notification_type_default
+        );
+
+        clic3_memory_free_raw(
+          notification_prefix
+        );
+
+        clic3_memory_free_raw(
+          notification
+        );
+
+        break;
+      }
+      case network_command_no_operation:
+      default: {
+        break;
+      }
+    }
+
+    network_data_packet_destroy(
+      &network_data_packet
     );
   }
 

--- a/sources/network/network_host.c
+++ b/sources/network/network_host.c
@@ -597,6 +597,10 @@ void network_host_data_map_client_index_send(
     &network_host_client->mutex
   );
 
+  network_host_client->status_game = (
+    network_client_status_game_loading
+  );
+
   network_host_client->command_sending = (
     network_command_data_map
   );

--- a/sources/network/network_host_client.c
+++ b/sources/network/network_host_client.c
@@ -1,13 +1,27 @@
 #include <network/network_host_client.h>
 
+#include <clic3_char_arrays.h>
+#include <clic3_memory.h>
+
 #include <unistd.h>
 
 void network_host_client_initialize(
   struct network_host_client* network_host_client,
-  int network_host_client_socket
+  int network_host_client_socket,
+  unsigned int index
 ) {
   network_host_client->socket = (
     network_host_client_socket
+  );
+
+  network_host_client->index = (
+    index
+  );
+
+  network_host_client->char_array_index = (
+    clic3_char_array_from_unsigned_long_int(
+      index
+    )
   );
 
   pthread_mutex_init(
@@ -46,5 +60,9 @@ void network_host_client_destroy(
 
   pthread_mutex_destroy(
     &network_host_client->mutex_sending
+  );
+
+  clic3_memory_free_raw(
+    network_host_client->char_array_index
   );
 }

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -11,12 +11,16 @@
 #include <mesh/mesh_hud_item.h>
 #include <mesh/mesh_player.h>
 #include <network/data/network_data_map_functions.h>
+#include <network/network_client.h>
+#include <network/network_client_status.h>
+#include <network/network_command.h>
 #include <network/network_host.h>
 #include <objects/object_crosshair.h>
 #include <objects/object_enemy.h>
 #include <player.h>
-
 #include <textures/textures_buildings.h>
+
+#include <clic3_memory.h>
 
 #include <metil.h>
 #include <metil_audio/metil_audio_io_proc.h>
@@ -469,6 +473,27 @@ void scene_gameplay_populate(
 
     metil_object_player->position.y = (
       scene->player.position.y
+    );
+
+    static struct network_data_packet* network_data_packet;
+
+    network_data_packet = (
+      clic3_memory_allocate_raw(
+        sizeof(
+          struct network_data_packet
+        )
+      )
+    );
+
+    network_data_packet_initialize(
+      network_data_packet,
+      network_command_data_map_loaded,
+      0
+    );
+
+    network_client_send(
+      network_client,
+      network_data_packet
     );
 
     return;


### PR DESCRIPTION
- `network_client_status_game`::add
- - statuses specific to gameplay rather than for network connection which is handled by `network_client_status`
- add buffered queue for outgoing `network_data_packet`s to `network_client`
- add notification to `network_host` for when `network_host_client` has loaded the `network_data_map`  

<img width="845" height="732" alt="Screenshot 2026-01-19 at 22 09 59" src="https://github.com/user-attachments/assets/8bf33c73-c7a2-4c1b-888b-d0390812fc61" />