### PR TITLE
`color`->`colour`::use_correct_spelling

### DIFF
--- a/include/data/enemy_data.h
+++ b/include/data/enemy_data.h
@@ -14,7 +14,7 @@ struct enemy_data {
 
   struct math_c_vector3_float position_previous;
 
-  struct math_c_vector3_float color;
+  struct math_c_vector3_float colour;
 
   matrix_float4x4 view_model_matrix_projection;
 };

--- a/include/data/projectile_data.h
+++ b/include/data/projectile_data.h
@@ -17,7 +17,7 @@ struct projectile_data {
 
   struct math_c_vector3_float position_previous;
 
-  struct math_c_vector3_float color;
+  struct math_c_vector3_float colour;
 
   matrix_float4x4 view_model_matrix_projection;
 };

--- a/metal/c938_building.metal
+++ b/metal/c938_building.metal
@@ -8,7 +8,7 @@ struct data_vertex {
   float4 position [[position]];
   float2 position_texture;
   float brightness;
-  float4 color;
+  float4 colour;
   float distance;
 };
 
@@ -49,11 +49,11 @@ struct data_vertex {
     : 1.0f
   ) : 0.013f);
 
-  data_vertex.color = float4(
-    data_object->color.x,
-    data_object->color.y,
-    data_object->color.z,
-    data_object->color.w
+  data_vertex.colour = float4(
+    data_object->colour.x,
+    data_object->colour.y,
+    data_object->colour.z,
+    data_object->colour.w
   );
 
   data_vertex.distance = metal::distance(
@@ -107,7 +107,7 @@ struct data_vertex {
     metal::s_address::repeat
   );
 
-  float4 color_texture = float4(
+  float4 colour_texture = float4(
     texture.sample(
       sampler_texture,
       data_vertex.position_texture / 100.0f
@@ -115,9 +115,9 @@ struct data_vertex {
   );
 
   return float4(
-    color_texture[0] * data_vertex.color.r * brightness,
-    color_texture[1] * data_vertex.color.g * brightness,
-    color_texture[2] * data_vertex.color.b * brightness,
-    data_vertex.color.a
+    colour_texture[0] * data_vertex.colour.r * brightness,
+    colour_texture[1] * data_vertex.colour.g * brightness,
+    colour_texture[2] * data_vertex.colour.b * brightness,
+    data_vertex.colour.a
   );
 }

--- a/metal/c938_crosshair.metal
+++ b/metal/c938_crosshair.metal
@@ -6,7 +6,7 @@
 
 struct data_vertex {
   float4 position [[position]];
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex c938_crosshair_vertex(
@@ -34,10 +34,10 @@ struct data_vertex {
     positions[id_vertex]
   );
 
-  data_vertex.color.r = data_object->color.x;
-  data_vertex.color.g = data_object->color.y;
-  data_vertex.color.b = data_object->color.z;
-  data_vertex.color.a = data_object->color.w;
+  data_vertex.colour.r = data_object->colour.x;
+  data_vertex.colour.g = data_object->colour.y;
+  data_vertex.colour.b = data_object->colour.z;
+  data_vertex.colour.a = data_object->colour.w;
 
   return data_vertex;
 }
@@ -46,9 +46,9 @@ struct data_vertex {
   data_vertex data_vertex [[stage_in]]
 ) {
   return float4(
-    data_vertex.color.r,
-    data_vertex.color.g,
-    data_vertex.color.b,
-    data_vertex.color.a
+    data_vertex.colour.r,
+    data_vertex.colour.g,
+    data_vertex.colour.b,
+    data_vertex.colour.a
   );
 }

--- a/metal/c938_default.metal
+++ b/metal/c938_default.metal
@@ -52,7 +52,7 @@ struct data_vertex {
     metal::mip_filter::linear
   );
 
-  float4 color_texture = float4(
+  float4 colour_texture = float4(
     texture.sample(
       sampler_texture,
       data_vertex.position_texture
@@ -60,9 +60,9 @@ struct data_vertex {
   );
 
   return float4(
-    color_texture[0] * data_vertex.brightness,
-    color_texture[1] * data_vertex.brightness,
-    color_texture[2] * data_vertex.brightness,
-    color_texture[3]
+    colour_texture[0] * data_vertex.brightness,
+    colour_texture[1] * data_vertex.brightness,
+    colour_texture[2] * data_vertex.brightness,
+    colour_texture[3]
   );
 }

--- a/metal/c938_enemy.metal
+++ b/metal/c938_enemy.metal
@@ -8,7 +8,7 @@
 struct data_vertex {
   float4 position [[position]];
   float brightness;
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex c938_enemy_vertex(
@@ -45,10 +45,10 @@ struct data_vertex {
     (float) enemy_data->life_maximum
   );
 
-  data_vertex.color = float4(
-    enemy_data->color.x * metal::fmin(percentage_life * 2.0f, 1.0f),
-    enemy_data->color.y * percentage_life,
-    enemy_data->color.z * percentage_life,
+  data_vertex.colour = float4(
+    enemy_data->colour.x * metal::fmin(percentage_life * 2.0f, 1.0f),
+    enemy_data->colour.y * percentage_life,
+    enemy_data->colour.z * percentage_life,
     1.0f
   );
 
@@ -60,9 +60,9 @@ struct data_vertex {
   metal::texture2d<half> texture [[texture(0)]]
 ) {
   return float4(
-    data_vertex.color.r * data_vertex.brightness,
-    data_vertex.color.g * data_vertex.brightness,
-    data_vertex.color.b * data_vertex.brightness,
-    data_vertex.color.a
+    data_vertex.colour.r * data_vertex.brightness,
+    data_vertex.colour.g * data_vertex.brightness,
+    data_vertex.colour.b * data_vertex.brightness,
+    data_vertex.colour.a
   );
 }

--- a/metal/c938_ground.metal
+++ b/metal/c938_ground.metal
@@ -73,7 +73,7 @@ struct data_vertex {
     metal::s_address::repeat
   );
 
-  float4 color_texture = float4(
+  float4 colour_texture = float4(
     texture.sample(
       sampler_texture,
       data_vertex.position_texture / 1000.0f
@@ -81,9 +81,9 @@ struct data_vertex {
   );
 
   return float4(
-    color_texture[0] * data_vertex.brightness,
-    color_texture[1] * data_vertex.brightness,
-    color_texture[2] * data_vertex.brightness,
-    color_texture[3]
+    colour_texture[0] * data_vertex.brightness,
+    colour_texture[1] * data_vertex.brightness,
+    colour_texture[2] * data_vertex.brightness,
+    colour_texture[3]
   );
 }

--- a/metal/c938_hud_item.metal
+++ b/metal/c938_hud_item.metal
@@ -7,7 +7,7 @@
 struct data_vertex {
   float4 position [[position]];
   float brightness;
-  float3 color;
+  float3 colour;
 };
 
 [[vertex]] struct data_vertex c938_hud_item_vertex(
@@ -37,9 +37,9 @@ struct data_vertex {
 
   data_vertex.brightness = data_frame->brightness_text;
 
-  data_vertex.color.r = (float) (2000 - data_object->noise) / 2000.0f;
-  data_vertex.color.g = (float) data_object->noise / 2000.0f;
-  data_vertex.color.b = (float) (data_object->noise % 2000) / 2000.0f;
+  data_vertex.colour.r = (float) (2000 - data_object->noise) / 2000.0f;
+  data_vertex.colour.g = (float) data_object->noise / 2000.0f;
+  data_vertex.colour.b = (float) (data_object->noise % 2000) / 2000.0f;
 
   return data_vertex;
 }
@@ -48,9 +48,9 @@ struct data_vertex {
   data_vertex data_vertex [[stage_in]]
 ) {
   return float4(
-    data_vertex.color.r * data_vertex.brightness,
-    data_vertex.color.g * data_vertex.brightness,
-    data_vertex.color.b * data_vertex.brightness,
+    data_vertex.colour.r * data_vertex.brightness,
+    data_vertex.colour.g * data_vertex.brightness,
+    data_vertex.colour.b * data_vertex.brightness,
     1.0f
   );
 }

--- a/metal/c938_player.metal
+++ b/metal/c938_player.metal
@@ -66,7 +66,7 @@ struct data_vertex {
     metal::mip_filter::linear
   );
 
-  float4 color_texture = float4(
+  float4 colour_texture = float4(
     texture.sample(
       sampler_texture,
       data_vertex.position_texture
@@ -74,9 +74,9 @@ struct data_vertex {
   );
 
   return float4(
-    color_texture[0] * data_vertex.brightness * 0.7f + 0.15f,
-    color_texture[1] * data_vertex.brightness * 0.5f,
-    color_texture[2] * data_vertex.brightness * 0.7f + 0.3f,
-    color_texture[3]
+    colour_texture[0] * data_vertex.brightness * 0.7f + 0.15f,
+    colour_texture[1] * data_vertex.brightness * 0.5f,
+    colour_texture[2] * data_vertex.brightness * 0.7f + 0.3f,
+    colour_texture[3]
   );
 }

--- a/metal/c938_projectile.metal
+++ b/metal/c938_projectile.metal
@@ -8,7 +8,7 @@
 struct data_vertex {
   float4 position [[position]];
   float brightness;
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex c938_projectile_vertex(
@@ -56,10 +56,10 @@ struct data_vertex {
     )
   );
 
-  data_vertex.color = float4(
-    projectile_data->color.x,
-    projectile_data->color.y,
-    projectile_data->color.z,
+  data_vertex.colour = float4(
+    projectile_data->colour.x,
+    projectile_data->colour.y,
+    projectile_data->colour.z,
     (1.0f - percentage_lifespan) *
     metal::fmin(
       id_vertex,
@@ -75,9 +75,9 @@ struct data_vertex {
   metal::texture2d<half> texture [[texture(0)]]
 ) {
   return float4(
-    data_vertex.color.r * data_vertex.brightness,
-    data_vertex.color.g * data_vertex.brightness,
-    data_vertex.color.b * data_vertex.brightness,
-    data_vertex.color.a
+    data_vertex.colour.r * data_vertex.brightness,
+    data_vertex.colour.g * data_vertex.brightness,
+    data_vertex.colour.b * data_vertex.brightness,
+    data_vertex.colour.a
   );
 }

--- a/metal/c938_text.metal
+++ b/metal/c938_text.metal
@@ -8,7 +8,7 @@ struct data_vertex {
   float4 position [[position]];
   float2 position_texture;
   float brightness;
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex c938_text_vertex(
@@ -40,20 +40,20 @@ struct data_vertex {
     data_frame->brightness_text
   );
 
-  data_vertex.color.r = (
-    data_object->color.x
+  data_vertex.colour.r = (
+    data_object->colour.x
   );
 
-  data_vertex.color.g = (
-    data_object->color.y
+  data_vertex.colour.g = (
+    data_object->colour.y
   );
 
-  data_vertex.color.b = (
-    data_object->color.z
+  data_vertex.colour.b = (
+    data_object->colour.z
   );
 
-  data_vertex.color.a = (
-    data_object->color.w
+  data_vertex.colour.a = (
+    data_object->colour.w
   );
 
   data_vertex.position_texture.x = (
@@ -80,7 +80,7 @@ struct data_vertex {
     metal::mip_filter::linear
   );
 
-  float4 color_texture = float4(
+  float4 colour_texture = float4(
     texture.sample(
       sampler_texture,
       data_vertex.position_texture
@@ -89,23 +89,23 @@ struct data_vertex {
 
   return float4(
     (
-      color_texture[0] *
-      data_vertex.color.r *
+      colour_texture[0] *
+      data_vertex.colour.r *
       data_vertex.brightness
     ),
     (
-      color_texture[1] *
-      data_vertex.color.g *
+      colour_texture[1] *
+      data_vertex.colour.g *
       data_vertex.brightness
     ),
     (
-      color_texture[2] *
-      data_vertex.color.b *
+      colour_texture[2] *
+      data_vertex.colour.b *
       data_vertex.brightness
     ),
     (
-      color_texture[3] *
-      data_vertex.color.a
+      colour_texture[3] *
+      data_vertex.colour.a
     )
   );
 }

--- a/metal/c938_text_backing_menu.metal
+++ b/metal/c938_text_backing_menu.metal
@@ -8,7 +8,7 @@ struct data_vertex {
   float4 position [[position]];
   float2 position_texture;
   float brightness;
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex c938_text_backing_menu_vertex(
@@ -56,20 +56,20 @@ struct data_vertex {
     )
   );
 
-  data_vertex.color.r = (
-    data_object->color.x
+  data_vertex.colour.r = (
+    data_object->colour.x
   );
 
-  data_vertex.color.g = (
-    data_object->color.y
+  data_vertex.colour.g = (
+    data_object->colour.y
   );
 
-  data_vertex.color.b = (
-    data_object->color.z
+  data_vertex.colour.b = (
+    data_object->colour.z
   );
 
-  data_vertex.color.a = (
-    data_object->color.w
+  data_vertex.colour.a = (
+    data_object->colour.w
   );
 
   data_vertex.position_texture.x = (
@@ -110,7 +110,7 @@ struct data_vertex {
     metal::s_address::repeat
   );
 
-  float4 color_texture = float4(
+  float4 colour_texture = float4(
     texture.sample(
       sampler_texture,
       (
@@ -122,23 +122,23 @@ struct data_vertex {
 
   return float4(
     (
-      color_texture[0] *
-      data_vertex.color.r *
+      colour_texture[0] *
+      data_vertex.colour.r *
       data_vertex.brightness
     ),
     (
-      color_texture[1] *
-      data_vertex.color.g *
+      colour_texture[1] *
+      data_vertex.colour.g *
       data_vertex.brightness
     ),
     (
-      color_texture[2] *
-      data_vertex.color.b *
+      colour_texture[2] *
+      data_vertex.colour.b *
       data_vertex.brightness
     ),
     (
-      color_texture[3] *
-      data_vertex.color.a
+      colour_texture[3] *
+      data_vertex.colour.a
     )
   );
 }

--- a/sources/c938.m
+++ b/sources/c938.m
@@ -85,22 +85,22 @@ void c938_renderer_on_initialize(
     @"c938_vertex"
   );
 
-  metil->renderer_interface.rendering_properties->color_clear.x = (
+  metil->renderer_interface.rendering_properties->colour_clear.x = (
     0.0f *
     metil->rendering_properties.brightness
   );
   
-  metil->renderer_interface.rendering_properties->color_clear.y = (
+  metil->renderer_interface.rendering_properties->colour_clear.y = (
     0.0f *
     metil->rendering_properties.brightness
   );
 
-  metil->renderer_interface.rendering_properties->color_clear.z = (
+  metil->renderer_interface.rendering_properties->colour_clear.z = (
     0.0f *
     metil->rendering_properties.brightness
   );
 
-  metil->renderer_interface.rendering_properties->color_clear.w = (
+  metil->renderer_interface.rendering_properties->colour_clear.w = (
     1.0f
   );
 

--- a/sources/generate/generate_buildings.m
+++ b/sources/generate/generate_buildings.m
@@ -262,15 +262,15 @@ void generate_buildings(
     if (
       index_building == index_target_building
     ) {
-      data->color.x = 0.0f;
-      data->color.y = 0.0f;
-      data->color.z = 1.0f;
-      data->color.w = 1.0f;
+      data->colour.x = 0.0f;
+      data->colour.y = 0.0f;
+      data->colour.z = 1.0f;
+      data->colour.w = 1.0f;
     } else {
-      data->color.x = 1.0f;
-      data->color.y = 1.0f;
-      data->color.z = 1.0f;
-      data->color.w = 1.0f;
+      data->colour.x = 1.0f;
+      data->colour.y = 1.0f;
+      data->colour.z = 1.0f;
+      data->colour.w = 1.0f;
     }
 
     struct math_c_vector2_float limits = {

--- a/sources/objects/object_crosshair.m
+++ b/sources/objects/object_crosshair.m
@@ -47,8 +47,8 @@ void object_crosshair_initialize(
     ].buffer.contents
   );
 
-  data->color.x = 1.0f;
-  data->color.y = 1.0f;
-  data->color.z = 1.0f;
-  data->color.w = 1.0f;
+  data->colour.x = 1.0f;
+  data->colour.y = 1.0f;
+  data->colour.z = 1.0f;
+  data->colour.w = 1.0f;
 }

--- a/sources/objects/object_enemy.m
+++ b/sources/objects/object_enemy.m
@@ -54,9 +54,9 @@ void object_enemy_initialize(
     ].buffer.contents
   );
 
-  enemy_data->color.x = 1.0f;
-  enemy_data->color.y = 1.0f;
-  enemy_data->color.z = 1.0f;
+  enemy_data->colour.x = 1.0f;
+  enemy_data->colour.y = 1.0f;
+  enemy_data->colour.z = 1.0f;
 
   enemy_data->speed = speed;
 

--- a/sources/objects/object_projectile.m
+++ b/sources/objects/object_projectile.m
@@ -53,9 +53,9 @@ void object_projectile_initialize(
     ].buffer.contents
   );
 
-  projectile_data->color.x = 0.7f;
-  projectile_data->color.y = 0.3f;
-  projectile_data->color.z = 1.0f;
+  projectile_data->colour.x = 0.7f;
+  projectile_data->colour.y = 0.3f;
+  projectile_data->colour.z = 1.0f;
 
   projectile_data->time_fired = time_fired;
   projectile_data->time_current = time_fired;

--- a/sources/scenes/scene_menu_main/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main/scene_menu_main.m
@@ -735,7 +735,7 @@ void scene_menu_main_poll(
         );
       }
 
-      metil_renderer_data_text_backing->color.x = (
+      metil_renderer_data_text_backing->colour.x = (
         0.8f
       );
 
@@ -743,32 +743,32 @@ void scene_menu_main_poll(
         menu == &data->menu_main &&
         index_menu == menus_menu_main_index_exit
       ) {
-        metil_renderer_data_text_backing->color.y = (
+        metil_renderer_data_text_backing->colour.y = (
           0.4f
         );
 
-        metil_renderer_data_text_backing->color.z = (
+        metil_renderer_data_text_backing->colour.z = (
           0.4f
         );
       } else {
-        metil_renderer_data_text_backing->color.y = (
+        metil_renderer_data_text_backing->colour.y = (
           0.8f
         );
 
-        metil_renderer_data_text_backing->color.z = (
+        metil_renderer_data_text_backing->colour.z = (
           0.8f
         );
       }
 
-      metil_renderer_data_text->color.x = (
+      metil_renderer_data_text->colour.x = (
         0.8f
       );
 
-      metil_renderer_data_text->color.y = (
+      metil_renderer_data_text->colour.y = (
         0.8f
       );
 
-      metil_renderer_data_text->color.z = (
+      metil_renderer_data_text->colour.z = (
         0.8f
       );
     } else {
@@ -789,7 +789,7 @@ void scene_menu_main_poll(
         offset_position_y
       );
 
-      metil_renderer_data_text_backing->color.x = (
+      metil_renderer_data_text_backing->colour.x = (
         1.0f
       );
 
@@ -797,32 +797,32 @@ void scene_menu_main_poll(
         menu == &data->menu_main &&
         index_menu == menus_menu_main_index_exit
       ) {
-        metil_renderer_data_text_backing->color.y = (
+        metil_renderer_data_text_backing->colour.y = (
           0.5f
         );
 
-        metil_renderer_data_text_backing->color.z = (
+        metil_renderer_data_text_backing->colour.z = (
           0.5f
         );
       } else {
-        metil_renderer_data_text_backing->color.y = (
+        metil_renderer_data_text_backing->colour.y = (
           1.0f
         );
 
-        metil_renderer_data_text_backing->color.z = (
+        metil_renderer_data_text_backing->colour.z = (
           1.0f
         );
       }
 
-      metil_renderer_data_text->color.x = (
+      metil_renderer_data_text->colour.x = (
         1.0f
       );
 
-      metil_renderer_data_text->color.y = (
+      metil_renderer_data_text->colour.y = (
         1.0f
       );
 
-      metil_renderer_data_text->color.z = (
+      metil_renderer_data_text->colour.z = (
         1.0f
       );
     }


### PR DESCRIPTION
- `color`->`colour`
- - use correct spelling