### PR TITLE
[bug|dev|enh] Sockets send new data maps

### DIFF
--- a/include/data/scene_gameplay_data.h
+++ b/include/data/scene_gameplay_data.h
@@ -9,6 +9,12 @@
 
 #define scene_gameplay_data_length_projectiles_maximum 200
 
+enum scene_gameplay_data_action_data_map {
+  scene_gameplay_data_action_data_map_none = 0,
+  scene_gameplay_data_action_data_map_parse = 1,
+  scene_gameplay_data_action_data_map_set = 2
+};
+
 struct scene_gameplay_data {
   struct metil_menu menu;
 
@@ -26,7 +32,7 @@ struct scene_gameplay_data {
 
   struct parameters_gameplay* parameters;
 
-  pthread_mutex_t mutex_data_map;
+  enum scene_gameplay_data_action_data_map action_data_map;
 };
 
 #endif

--- a/include/network/network_host.h
+++ b/include/network/network_host.h
@@ -19,7 +19,7 @@ enum network_host_notification_type {
 struct network_host {
   int socket;
 
-  struct network_host_client* clients;
+  struct network_host_client** clients;
   unsigned int length_clients;
 
   struct sockaddr_in address_socket;
@@ -42,6 +42,7 @@ struct network_host {
 
 struct network_host_client_thread_data {
   struct network_host* network_host;
+  struct network_host_client* network_host_client;
   unsigned int index_client;
 };
 

--- a/sources/network/network_host.c
+++ b/sources/network/network_host.c
@@ -358,14 +358,6 @@ void* network_host_routing_thread(
       network_host->length_clients
     );
 
-    clic3_bytes_copy(
-      network_host_client_sending_thread_data,
-      network_host_client_receiving_thread_data,
-      sizeof(
-        struct network_host_client_thread_data
-      )
-    );
-
     network_host->length_clients = (
       network_host->length_clients +
       1
@@ -375,13 +367,23 @@ void* network_host_routing_thread(
       &network_host->clients,
       (
         sizeof(
-          struct network_host_client
+          struct network_host_client*
         ) *
         network_host->length_clients
       )
     );
 
-    struct network_host_client* network_host_client = &(
+    network_host->clients[
+      network_host_client_receiving_thread_data->index_client
+    ] = (
+      clic3_memory_allocate_raw(
+        sizeof(
+          struct network_host_client
+        )
+      )
+    );
+
+    struct network_host_client* network_host_client = (
       network_host->clients[
         network_host_client_receiving_thread_data->index_client
       ]
@@ -391,6 +393,18 @@ void* network_host_routing_thread(
       network_host_client,
       socket_client,
       network_host_client_receiving_thread_data->index_client
+    );
+
+    network_host_client_receiving_thread_data->network_host_client = (
+      network_host_client
+    );
+
+    clic3_bytes_copy(
+      network_host_client_sending_thread_data,
+      network_host_client_receiving_thread_data,
+      sizeof(
+        struct network_host_client_thread_data
+      )
     );
 
     pthread_create(
@@ -437,10 +451,8 @@ void* network_host_client_receiving_thread(
     network_host_client_thread_data->network_host
   );
 
-  struct network_host_client* network_host_client = &(
-    network_host->clients[
-      network_host_client_thread_data->index_client
-    ]
+  struct network_host_client* network_host_client = (
+    network_host_client_thread_data->network_host_client
   );
 
   while (
@@ -471,6 +483,8 @@ void* network_host_client_receiving_thread(
       network_host_client->status = (
         network_client_status_disconnected
       );
+
+      continue;
     }
 
     struct network_data_packet network_data_packet;
@@ -583,10 +597,8 @@ void* network_host_client_sending_thread(
     network_host_client_thread_data->network_host
   );
 
-  struct network_host_client* network_host_client = &(
-    network_host->clients[
-      network_host_client_thread_data->index_client
-    ]
+  struct network_host_client* network_host_client = (
+    network_host_client_thread_data->network_host_client
   );
 
   unsigned char quitting = 0;
@@ -668,7 +680,7 @@ void network_host_data_map_client_index_send(
   struct network_host* network_host,
   unsigned int index_client
 ) {
-  struct network_host_client* network_host_client = &(
+  struct network_host_client* network_host_client = (
     network_host->clients[
       index_client
     ]
@@ -755,7 +767,7 @@ void network_host_destroy(
     index_client < network_host->length_clients;
     ++index_client
   ) {
-    struct network_host_client* network_host_client = &(
+    struct network_host_client* network_host_client = (
       network_host->clients[
         index_client
       ]
@@ -794,13 +806,17 @@ void network_host_destroy(
     index_client < network_host->length_clients;
     ++index_client
   ) {
-    struct network_host_client* network_host_client = &(
+    struct network_host_client* network_host_client = (
       network_host->clients[
         index_client
       ]
     );
 
     network_host_client_destroy(
+      network_host_client
+    );
+
+    clic3_memory_free_raw(
       network_host_client
     );
   }

--- a/sources/network/network_host.c
+++ b/sources/network/network_host.c
@@ -519,6 +519,41 @@ void* network_host_client_receiving_thread(
 
         break;
       }
+      case network_command_data_map: {
+        network_host_client->status_game = (
+          network_client_status_game_loading
+        );
+
+        char* notification_prefix = (
+          clic3_char_arrays_concatenate(
+            "network_host_client::requested_data_map->{",
+            network_host_client->char_array_index
+          )
+        );
+
+        char* notification = (
+          clic3_char_arrays_concatenate(
+            notification_prefix,
+            "};"
+          )
+        );
+
+        notification_manager_send(
+          &network_host->notification_manager,
+          notification,
+          network_host_notification_type_default
+        );
+
+        clic3_memory_free_raw(
+          notification_prefix
+        );
+
+        clic3_memory_free_raw(
+          notification
+        );
+
+        break;
+      }
       case network_command_no_operation:
       default: {
         break;

--- a/sources/network/network_host.c
+++ b/sources/network/network_host.c
@@ -396,7 +396,7 @@ void* network_host_routing_thread(
     pthread_create(
       &network_host->threads[
         network_host->length_threads -
-        1
+        2
       ],
       0,
       network_host_client_receiving_thread,

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -94,6 +94,10 @@ void scene_gameplay_initialize(
 
   scene_gameplay_data->length_projectiles = 0;
 
+  scene_gameplay_data->action_data_map = (
+    scene_gameplay_data_action_data_map_none
+  );
+
   for (
     unsigned char index_projectile = 0;
     index_projectile < scene_gameplay_data_length_projectiles_maximum;
@@ -330,23 +334,18 @@ void scene_gameplay_initialize(
     scene_gameplay_data->parameters->networked !=
     parameters_gameplay_networked_none
   ) {
-    pthread_mutex_init(
-      &scene_gameplay_data->mutex_data_map,
-      0
-    );
-
     struct c938_data* c938_data = (
       metil->data
-    );
-
-    struct network_host* network_host = (
-      &c938_data->network_host
     );
 
     if (
       scene_gameplay_data->parameters->networked ==
       parameters_gameplay_networked_host
     ) {
+      struct network_host* network_host = (
+        &c938_data->network_host
+      );
+
       notification_manager_notification_on_add(
         &network_host->notification_manager,
         scene_gameplay_network_host_notification_on,
@@ -356,8 +355,12 @@ void scene_gameplay_initialize(
       scene_gameplay_data->parameters->networked ==
       parameters_gameplay_networked_client
     ) {
+      struct network_client* network_client = (
+        &c938_data->network_client
+      );
+
       notification_manager_notification_on_add(
-        &network_host->notification_manager,
+        &network_client->notification_manager,
         scene_gameplay_network_client_notification_on,
         metil
       );
@@ -378,6 +381,14 @@ void scene_gameplay_network_client_notification_on(
     data
   );
 
+  struct c938_data* c938_data = (
+    metil->data
+  );
+
+  struct network_client* network_client = &(
+    c938_data->network_client
+  );
+
   struct metil_scene_controller* metil_scene_controller = (
     metil->scene_controller
   );
@@ -394,12 +405,8 @@ void scene_gameplay_network_client_notification_on(
     notification_id
   ) {
     case network_client_notification_type_data_map_sent: {
-      pthread_mutex_lock(
-        &scene_gameplay_data->mutex_data_map
-      );
-
-      pthread_mutex_unlock(
-        &scene_gameplay_data->mutex_data_map
+      scene_gameplay_data->action_data_map = (
+        scene_gameplay_data_action_data_map_parse
       );
       break;
     }
@@ -421,6 +428,14 @@ void scene_gameplay_network_host_notification_on(
     data
   );
 
+  struct c938_data* c938_data = (
+    metil->data
+  );
+
+  struct network_host* network_host = &(
+    c938_data->network_host
+  );
+
   struct metil_scene_controller* metil_scene_controller = (
     metil->scene_controller
   );
@@ -437,12 +452,8 @@ void scene_gameplay_network_host_notification_on(
     notification_id
   ) {
     case network_host_notification_type_data_map_requested: {
-      pthread_mutex_lock(
-        &scene_gameplay_data->mutex_data_map
-      );
-
-      pthread_mutex_unlock(
-        &scene_gameplay_data->mutex_data_map
+      scene_gameplay_data->action_data_map = (
+        scene_gameplay_data_action_data_map_set
       );
       break;
     }
@@ -927,20 +938,91 @@ void scene_gameplay_populate(
 
 void scene_gameplay_poll(
   struct metil* metil,
-  struct metil_scene* scene
+  struct metil_scene* metil_scene_gameplay
 ) {
   struct scene_gameplay_data* scene_gameplay_data = (
-    scene->data
+    metil_scene_gameplay->data
   );
 
   struct player_data* player_data = (
-    scene->player.data
+    metil_scene_gameplay->player.data
+  );
+
+  struct metil_group* metil_group_enemies = (
+    metil_scene_gameplay->renderables[
+      scene_gameplay_renderables_index_enemies
+    ].renderable
+  );
+
+  struct metil_group* metil_group_projectiles = (
+    metil_scene_gameplay->renderables[
+      scene_gameplay_renderables_index_projectiles
+    ].renderable
   );
 
   c938_logging_poll(
     metil
   );
 
+  if (
+    scene_gameplay_data->parameters->networked !=
+    parameters_gameplay_networked_none
+  ) {
+    struct c938_data* c938_data = (
+      metil->data
+    );
+
+    struct network_client* network_client = &(
+      c938_data->network_client
+    );
+
+    struct network_host* network_host = &(
+      c938_data->network_host
+    );
+
+    struct metil_group* metil_group_buildings = (
+      metil_scene_gameplay->renderables[
+        scene_gameplay_renderables_index_buildings
+      ].renderable
+    );
+
+    switch (
+      scene_gameplay_data->action_data_map
+    ) {
+      case scene_gameplay_data_action_data_map_parse: {
+        scene_gameplay_populate(
+          metil,
+          metil_scene_gameplay,
+          1
+        );
+
+        break;
+      }
+      case scene_gameplay_data_action_data_map_set: {
+        network_data_map_set(
+          &network_host->data_map,
+          scene_gameplay_data->parameters,
+          metil_group_buildings,
+          metil_group_enemies,
+          &metil_scene_gameplay->player.position,
+          player_data->index_target_building
+        );
+
+        network_host_data_map_send(
+          network_host
+        );
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+
+    scene_gameplay_data->action_data_map = (
+      scene_gameplay_data_action_data_map_none
+    );
+  }
+  
   if (
     player_data->on_ground == (
       player_data->index_target_building +
@@ -949,37 +1031,25 @@ void scene_gameplay_poll(
   ) {
     scene_gameplay_populate(
       metil,
-      scene,
+      metil_scene_gameplay,
       0
     );
 
     return;
   } else if (
-    scene->player.position.y <= 10.0f
+    metil_scene_gameplay->player.position.y <= 10.0f
   ) {
     scene_gameplay_populate(
       metil,
-      scene,
+      metil_scene_gameplay,
       1
     );
 
     return;
   }
 
-  struct metil_group* metil_group_projectiles = (
-    scene->renderables[
-      scene_gameplay_renderables_index_projectiles
-    ].renderable
-  );
-
-  struct metil_group* metil_group_enemies = (
-    scene->renderables[
-      scene_gameplay_renderables_index_enemies
-    ].renderable
-  );
-
   float time_delta_percent = (
-    (float) scene->time_delta /
+    (float) metil_scene_gameplay->time_delta /
     1000.0f
   );
 
@@ -1052,7 +1122,7 @@ void scene_gameplay_poll(
     );
 
     projectile_data->time_current = (
-      scene->time
+      metil_scene_gameplay->time
     );
 
     projectile_data->time_delta_percent = (
@@ -1089,14 +1159,14 @@ void scene_gameplay_poll(
     );
 
     if (
-      scene->player.position.x >= metil_object_enemy->position.x - (metil_object_enemy->mesh.size.x / 2.0f) &&
-      scene->player.position.x <= metil_object_enemy->position.x + (metil_object_enemy->mesh.size.x / 2.0f) &&
+      metil_scene_gameplay->player.position.x >= metil_object_enemy->position.x - (metil_object_enemy->mesh.size.x / 2.0f) &&
+      metil_scene_gameplay->player.position.x <= metil_object_enemy->position.x + (metil_object_enemy->mesh.size.x / 2.0f) &&
 
-      (scene->player.position.y + player_data->height) >= metil_object_enemy->position.y - (metil_object_enemy->mesh.size.y / 2.0f) &&
-      (scene->player.position.y + player_data->height) <= metil_object_enemy->position.y + (metil_object_enemy->mesh.size.y / 2.0f) &&
+      (metil_scene_gameplay->player.position.y + player_data->height) >= metil_object_enemy->position.y - (metil_object_enemy->mesh.size.y / 2.0f) &&
+      (metil_scene_gameplay->player.position.y + player_data->height) <= metil_object_enemy->position.y + (metil_object_enemy->mesh.size.y / 2.0f) &&
 
-      scene->player.position.z >= metil_object_enemy->position.z - (metil_object_enemy->mesh.size.z / 2.0f) &&
-      scene->player.position.z <= metil_object_enemy->position.z + (metil_object_enemy->mesh.size.z / 2.0f)
+      metil_scene_gameplay->player.position.z >= metil_object_enemy->position.z - (metil_object_enemy->mesh.size.z / 2.0f) &&
+      metil_scene_gameplay->player.position.z <= metil_object_enemy->position.z + (metil_object_enemy->mesh.size.z / 2.0f)
     ) {
       player_data->life = (
         player_data->life -
@@ -1114,7 +1184,7 @@ void scene_gameplay_poll(
       ) {
         scene_gameplay_populate(
           metil,
-          scene,
+          metil_scene_gameplay,
           1
         );
 
@@ -1136,7 +1206,7 @@ void scene_gameplay_poll(
   ) {
     scene_gameplay_populate(
       metil,
-      scene,
+      metil_scene_gameplay,
       1
     );
 
@@ -1145,21 +1215,21 @@ void scene_gameplay_poll(
 
   metil_scene_poll_default(
     metil,
-    scene
+    metil_scene_gameplay
   );
 
   struct metil_object* object = (
-    scene->renderables[
+    metil_scene_gameplay->renderables[
       scene_gameplay_renderables_index_player
     ].renderable
   );
 
-  object->position.x = scene->player.position.x;
-  object->position.y = scene->player.position.y;
-  object->position.z = scene->player.position.z;
+  object->position.x = metil_scene_gameplay->player.position.x;
+  object->position.y = metil_scene_gameplay->player.position.y;
+  object->position.z = metil_scene_gameplay->player.position.z;
 
   object = (
-    scene->renderables[
+    metil_scene_gameplay->renderables[
       scene_gameplay_renderables_index_hud_boosted
     ].renderable
   );
@@ -1174,7 +1244,7 @@ void scene_gameplay_poll(
     player_data->is_boosted == 1
   ) {
     unsigned long int delta_time_boost = (
-      scene->time_input -
+      metil_scene_gameplay->time_input -
       player_data->time_boost
     );
 
@@ -1188,7 +1258,7 @@ void scene_gameplay_poll(
   }
 
   object = (
-    scene->renderables[
+    metil_scene_gameplay->renderables[
       scene_gameplay_renderables_index_hud_jumping
     ].renderable
   );
@@ -1204,7 +1274,7 @@ void scene_gameplay_poll(
   );
 
   object = (
-    scene->renderables[
+    metil_scene_gameplay->renderables[
       scene_gameplay_renderables_index_hud_jumping_secondary
     ].renderable
   );
@@ -1232,19 +1302,6 @@ void scene_gameplay_destroy(
   struct scene_gameplay_data* scene_gameplay_data = (
     metil_scene_gameplay->data
   );
-
-  if (
-    scene_gameplay_data->parameters->networked !=
-    parameters_gameplay_networked_none
-  ) {
-    struct scene_gameplay_data* scene_gameplay_data = (
-      metil_scene_gameplay->data
-    );
-
-    pthread_mutex_destroy(
-      &scene_gameplay_data->mutex_data_map
-    );
-  }
 
   clic3_memory_free_raw(
     metil_scene_gameplay->data


### PR DESCRIPTION
- sends new data map when repopulation occurs
- fix pthread indexing in `network_host`
- fix client memory addressing in `network_host` threads


https://github.com/user-attachments/assets/21dbbccb-a0cc-467b-9670-d032924420f2


https://github.com/user-attachments/assets/a1e9578e-118a-48d5-bbc3-081390a70c68

