### PR TITLE
[enh] Sockets player movement

### DIFF
--- a/include/network/network_client.h
+++ b/include/network/network_client.h
@@ -46,6 +46,8 @@ struct network_client {
 
   struct network_data_packet** network_data_packets_outgoing;
   unsigned int length_network_data_packets_outgoing;
+
+  unsigned int connected_players;
 };
 
 struct network_client_thread_data {

--- a/include/network/network_client.h
+++ b/include/network/network_client.h
@@ -17,7 +17,8 @@
 enum network_client_notification_type {
   network_client_notification_type_default = 0,
   network_client_notification_type_error = 1,
-  network_client_notification_type_data_map_sent = 2
+  network_client_notification_type_data_map_sent = 2,
+  network_client_notification_type_poll = 3
 };
 
 struct network_client {
@@ -43,11 +44,14 @@ struct network_client {
   pthread_mutex_t mutex_sending;
   pthread_mutex_t mutex_thread_sending;
   pthread_mutex_t mutex_network_data_packets_outgoing;
+  pthread_mutex_t mutex_poll;
 
   struct network_data_packet** network_data_packets_outgoing;
   unsigned int length_network_data_packets_outgoing;
 
   unsigned int connected_players;
+
+  struct network_data_packet* network_data_packet_poll;
 };
 
 struct network_client_thread_data {

--- a/include/network/network_command.h
+++ b/include/network/network_command.h
@@ -6,7 +6,8 @@ enum network_command {
   network_command_initialize = 0x01,
   network_command_data_map = 0x02,
   network_command_data_map_loaded = 0x03,
-  network_command_disconnecting = 0x04,
+  network_command_poll = 0x04,
+  network_command_disconnecting = 0x05,
   network_command_error = 0xfe,
   network_command_unknown = 0xff
 };

--- a/include/network/network_host.h
+++ b/include/network/network_host.h
@@ -38,6 +38,8 @@ struct network_host {
   fd_set file_descriptor_socket_set;
 
   struct network_data_map data_map;
+
+  unsigned int connected_players;
 };
 
 struct network_host_client_thread_data {

--- a/include/network/network_host.h
+++ b/include/network/network_host.h
@@ -32,6 +32,7 @@ struct network_host {
   pthread_t* threads;
 
   pthread_mutex_t mutex_thread;
+  pthread_mutex_t mutex_position;
 
   struct notification_manager notification_manager;
 
@@ -39,6 +40,7 @@ struct network_host {
 
   struct network_data_map data_map;
 
+  struct math_c_vector3_float position;
   unsigned int connected_players;
 };
 
@@ -76,6 +78,10 @@ void network_host_data_map_client_index_send(
 );
 
 void network_host_data_map_send(
+  struct network_host*
+);
+
+void network_host_send_poll(
   struct network_host*
 );
 

--- a/include/network/network_host_client.h
+++ b/include/network/network_host_client.h
@@ -5,6 +5,8 @@
 #include <network/network_client_status_game.h>
 #include <network/network_command.h>
 
+#include <math_c_vector.h>
+
 #include <pthread.h>
 
 struct network_host_client {
@@ -20,6 +22,8 @@ struct network_host_client {
   enum network_client_status_game status_game;
 
   enum network_command command_sending;
+
+  struct math_c_vector3_float position;
 };
 
 void network_host_client_initialize(

--- a/include/scenes/scene_gameplay.h
+++ b/include/scenes/scene_gameplay.h
@@ -17,7 +17,7 @@
 
 enum scene_gameplay_renderables_index {
   scene_gameplay_renderables_index_buildings = 0,
-  scene_gameplay_renderables_index_player = 1,
+  scene_gameplay_renderables_index_group_players = 1,
   scene_gameplay_renderables_index_projectiles = 2,
   scene_gameplay_renderables_index_enemies = 3,
   scene_gameplay_renderables_index_hud_boosted = 4,

--- a/metal/c938_player.metal
+++ b/metal/c938_player.metal
@@ -74,9 +74,9 @@ struct data_vertex {
   );
 
   return float4(
-    colour_texture[0] * data_vertex.brightness * 0.7f + 0.15f,
+    1.0f,//colour_texture[0] * data_vertex.brightness * 0.7f + 0.15f,
     colour_texture[1] * data_vertex.brightness * 0.5f,
     colour_texture[2] * data_vertex.brightness * 0.7f + 0.3f,
-    colour_texture[3]
+    1.0f
   );
 }

--- a/sources/mesh/mesh_player.c
+++ b/sources/mesh/mesh_player.c
@@ -3,41 +3,70 @@
 #include <metil_mesh/metil_mesh.h>
 #include <metil_player/metil_player_defaults.h>
 
+#include <clic3_memory.h>
+
 #include <math_c_vector.h>
 
 #include <math.h>
-#include <stdlib.h>
 
 void mesh_player_initialize(
   struct metil_mesh* mesh,
   struct metil_player_defaults* metil_player_defaults
 ) {
-  metil_mesh_initialize(mesh);
+  metil_mesh_initialize(
+    mesh
+  );
 
-  mesh->size.x = metil_player_defaults->size.x;
-  mesh->size.y = metil_player_defaults->size.y;
-  mesh->size.z = metil_player_defaults->size.z;
+  mesh->size.x = (
+    metil_player_defaults->size.x
+  );
+
+  mesh->size.y = (
+    metil_player_defaults->size.y
+  );
+
+  mesh->size.z = (
+    metil_player_defaults->size.z
+  );
 
   mesh->length_vertices = 14;
+
   mesh->length_indices = (
-    (mesh->length_vertices - 1) * 3
+    (
+      mesh->length_vertices -
+      1
+    ) *
+    3
   );
 
-  mesh->indices = realloc(
-    mesh->indices,
-    sizeof(unsigned int) *
-    mesh->length_indices
+  clic3_memory_reallocate_raw(
+    &mesh->indices,
+    (
+      sizeof(
+        unsigned int
+      ) *
+      mesh->length_indices
+    )
   );
 
-  mesh->vertices = realloc(
-    mesh->vertices,
-    sizeof(struct math_c_vector4_float) *
-    mesh->length_vertices
+  clic3_memory_reallocate_raw(
+    &mesh->vertices,
+    (
+      sizeof(
+        struct math_c_vector4_float
+      ) *
+      mesh->length_vertices
+    )
   );
 
   mesh->vertices[0].x = 0;
-  mesh->vertices[0].y = metil_player_defaults->size.y;
+  
+  mesh->vertices[0].y = (
+    metil_player_defaults->size.y
+  );
+  
   mesh->vertices[0].z = 0;
+
   mesh->vertices[0].w = 1.0f;
 
   for (
@@ -46,24 +75,79 @@ void mesh_player_initialize(
     ++index_vertex
   ) {
     float angle = (
-      ((float) (index_vertex - 1)) /
-      ((float) (mesh->length_vertices - 2)) *
-      M_PI * 2.0f
+      (
+        (float)
+        (
+          index_vertex -
+          1
+        )
+      ) /
+      (
+        (float)
+        (
+          mesh->length_vertices -
+          2
+        )
+      ) *
+      M_PI *
+      2.0f
     );
     
-    mesh->vertices[index_vertex].x = cos(angle) * metil_player_defaults->size.x;
-    mesh->vertices[index_vertex].y = 0;
-    mesh->vertices[index_vertex].z = sin(angle) * metil_player_defaults->size.z;
-    mesh->vertices[index_vertex].w = 1.0f;
+    mesh->vertices[
+      index_vertex
+    ].x = (
+      cos(
+        angle
+      ) *
+      metil_player_defaults->size.x
+    );
+    
+    mesh->vertices[
+      index_vertex
+    ].y = 0;
+    
+    mesh->vertices[
+      index_vertex
+    ].z = (
+      sin(
+        angle
+      ) *
+      metil_player_defaults->size.z
+    );
+    
+    mesh->vertices[
+      index_vertex
+    ].w = 1.0f;
   }
 
   for (
     unsigned char index_index = 0;
-    index_index < mesh->length_indices / 3;
+    index_index < (
+      mesh->length_indices /
+      3
+    );
     ++index_index
   ) {
-    mesh->indices[index_index * 3] = 0;
-    mesh->indices[index_index * 3 + 1] = index_index;
-    mesh->indices[index_index * 3 + 2] = index_index + 1;
+    mesh->indices[
+      index_index *
+      3
+    ] = 0;
+
+    mesh->indices[
+      index_index *
+      3 +
+      1
+    ] = (
+      index_index
+    );
+
+    mesh->indices[
+      index_index *
+      3 +
+      2
+    ] = (
+      index_index +
+      1
+    );
   }
 }

--- a/sources/network/network_client.c
+++ b/sources/network/network_client.c
@@ -194,6 +194,8 @@ unsigned char network_client_connect_with_notification(
     0
   );
 
+  network_client->connected_players = 0;
+
   notification_manager_initialize(
     &network_client->notification_manager
   );

--- a/sources/network/network_client.c
+++ b/sources/network/network_client.c
@@ -124,6 +124,8 @@ unsigned char network_client_connect_with_notification(
     &network_client->data_map
   );
 
+  network_client->network_data_packet_poll = 0;
+
   network_client->status = (
     network_client_status_initialized |
     network_client_status_connected
@@ -173,6 +175,11 @@ unsigned char network_client_connect_with_notification(
 
   pthread_mutex_init(
     &network_client->mutex_thread_sending,
+    0
+  );
+
+  pthread_mutex_init(
+    &network_client->mutex_poll,
     0
   );
 
@@ -304,6 +311,14 @@ void* network_client_receiving_thread(
           network_client_status_game_disconnected
         );
 
+        network_data_packet_destroy(
+          network_data_packet
+        );
+
+        clic3_memory_free_raw(
+          network_data_packet
+        );
+
         break;
       }
       case network_command_data_map: {
@@ -320,9 +335,44 @@ void* network_client_receiving_thread(
 
         break;
       }
+      case network_command_poll:
+        pthread_mutex_lock(
+          &network_client->mutex_poll
+        );
+
+        if (
+          network_client->network_data_packet_poll != 0
+        ) {
+          network_data_packet_destroy(
+            network_client->network_data_packet_poll
+          );
+
+          clic3_memory_free_raw(
+            network_client->network_data_packet_poll
+          );
+        }
+
+        network_client->network_data_packet_poll = (
+          network_data_packet
+        );
+
+        pthread_mutex_unlock(
+          &network_client->mutex_poll
+        );
+
+        notification_manager_send(
+          &network_client->notification_manager,
+          "network_client::poll",
+          network_client_notification_type_poll
+        );
+        break;
       case network_command_initialize:
       case network_command_no_operation:
       default: {
+        network_data_packet_destroy(
+          network_data_packet
+        );
+
         clic3_memory_free_raw(
           network_data_packet
         );
@@ -597,6 +647,10 @@ void network_client_destroy(
 
   pthread_mutex_destroy(
     &network_client->mutex_network_data_packets_outgoing
+  );
+
+  pthread_mutex_destroy(
+    &network_client->mutex_poll
   );
 
   network_data_map_destroy(

--- a/sources/network/network_host.c
+++ b/sources/network/network_host.c
@@ -1,5 +1,6 @@
 #include <network/network_host.h>
 
+#include <data/data_length.h>
 #include <network/data/network_data_packet.h>
 #include <network/network.h>
 #include <network/network_client_status.h>
@@ -112,6 +113,11 @@ unsigned char network_host_listen_with_notification(
     0
   );
 
+  pthread_mutex_init(
+    &network_host->mutex_position,
+    0
+  );
+
   network_host->length_threads = (
     1
   );
@@ -150,7 +156,7 @@ unsigned char network_host_listen_with_notification(
   }
 
   network_host->initialized = 1;
-  network_host->connected_players = 1;
+  network_host->connected_players = 0;
 
   notification_manager_send(
     &network_host->notification_manager,
@@ -441,6 +447,15 @@ void* network_host_routing_thread(
       network_host,
       network_host_client_sending_thread_data->index_client
     );
+
+    network_host_client->status = (
+      network_client_status_connected
+    );
+
+    network_host->connected_players = (
+      network_host->connected_players +
+      1
+    );
   }
 
   return 0;
@@ -614,6 +629,25 @@ void* network_host_client_receiving_thread(
 
         break;
       }
+      case network_command_poll: {
+        pthread_mutex_lock(
+          &network_host->mutex_position
+        );
+
+        network_data_packet_read(
+          &network_data_packet,
+          &network_host_client->position,
+          sizeof(
+            struct math_c_vector3_float
+          )
+        );
+
+        pthread_mutex_unlock(
+          &network_host->mutex_position
+        );
+
+        break;
+      }
       case network_command_no_operation:
       default: {
         break;
@@ -631,6 +665,11 @@ void* network_host_client_receiving_thread(
 
   network_host_client->status = (
     network_client_status_disconnected
+  );
+
+  network_host->connected_players = (
+    network_host->connected_players -
+    1
   );
 
   char* notification_prefix = (
@@ -840,6 +879,128 @@ void network_host_data_map_send(
   );
 }
 
+void network_host_send_poll(
+  struct network_host* network_host
+) {
+  pthread_mutex_lock(
+    &network_host->mutex_thread
+  );
+
+  pthread_mutex_lock(
+    &network_host->mutex_position
+  );
+
+  struct network_data_packet network_data_packet;
+
+  network_data_packet_initialize(
+    &network_data_packet,
+    network_command_poll,
+    (
+      sizeof(
+        unsigned int
+      ) *
+      2 +
+      sizeof(
+        struct math_c_vector3_float 
+      ) *
+      (
+        network_host->connected_players +
+        1
+      )
+    )
+  );
+
+  unsigned int index = (
+    network_host->connected_players +
+    1
+  );
+
+  network_data_packet_bytes_add(
+    &network_data_packet,
+    &index,
+    data_length_unsigned_int
+  );
+
+  network_data_packet_bytes_add(
+    &network_data_packet,
+    &index,
+    data_length_unsigned_int
+  );
+
+  for (
+    unsigned int index_client = 0;
+    index_client < network_host->length_clients;
+    ++index_client
+  ) {
+    struct network_host_client* network_host_client = (
+      network_host->clients[
+        index_client
+      ]
+    );
+
+    if (
+      network_host_client->status &
+      network_client_status_connected
+    ) {
+      network_data_packet_bytes_add(
+        &network_data_packet,
+        &network_host_client->position,
+        data_length_math_c_vector3_float
+      );
+    }
+  }
+
+  network_data_packet_bytes_add(
+    &network_data_packet,
+    &network_host->position,
+    data_length_math_c_vector3_float
+  );
+
+  pthread_mutex_unlock(
+    &network_host->mutex_position
+  );
+
+  for (
+    unsigned int index_client = 0;
+    index_client < network_host->length_clients;
+    ++index_client
+  ) {
+    
+    struct network_host_client* network_host_client = (
+      network_host->clients[
+        index_client
+      ]
+    );
+
+    if (
+      network_host_client->status &
+      network_client_status_connected
+    ) {
+      clic3_bytes_copy(
+        (
+          network_data_packet.bytes +
+          1
+        ),
+        &index_client,
+        data_length_unsigned_int
+      );
+
+      network_data_packet_send(
+        &network_data_packet,
+        network_host_client->socket
+      );
+    }
+  }
+
+  network_data_packet_destroy(
+    &network_data_packet
+  );
+
+  pthread_mutex_unlock(
+    &network_host->mutex_thread
+  );
+}
+
 void network_host_connections_accept(
   struct network_host* network_host
 ) {
@@ -957,6 +1118,10 @@ void network_host_destroy(
 
   pthread_mutex_destroy(
     &network_host->mutex_thread
+  );
+
+  pthread_mutex_destroy(
+    &network_host->mutex_position
   );
 
   network_data_map_destroy(

--- a/sources/network/network_host.c
+++ b/sources/network/network_host.c
@@ -150,6 +150,7 @@ unsigned char network_host_listen_with_notification(
   }
 
   network_host->initialized = 1;
+  network_host->connected_players = 1;
 
   notification_manager_send(
     &network_host->notification_manager,

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -138,6 +138,7 @@ void scene_gameplay_initialize(
       index_renderable
     ) {
       case scene_gameplay_renderables_index_buildings:
+      case scene_gameplay_renderables_index_group_players:
       case scene_gameplay_renderables_index_projectiles:
       case scene_gameplay_renderables_index_enemies:
         metil_renderable_initialize_at_index(
@@ -172,39 +173,82 @@ void scene_gameplay_initialize(
     }
   }
 
-  struct metil_object* object = (
-    scene->renderables[
-      scene_gameplay_renderables_index_player
-    ].renderable
-  );
-
-  object->index_pipeline_render = (
-    c938_pipeline_index_player
-  );
-
   for (
     unsigned char index_renderable = scene_gameplay_renderables_index_range_hud_start;
     index_renderable < scene_gameplay_renderables_index_range_hud_end + 1;
     ++index_renderable
   ) {
-    object = scene->renderables[
-      index_renderable
-    ].renderable;
+    struct metil_object* metil_object_hud = (
+      scene->renderables[
+        index_renderable
+      ].renderable
+    );
 
     mesh_hud_item_initialize(
-      &object->mesh
+      &metil_object_hud->mesh
     );
 
     metil_object_buffers_initialize(
-      object,
+      metil_object_hud,
       metil->renderer_interface.metal_device
     );
 
-    object->positioning = metil_positioning_static;
+    metil_object_hud->positioning = metil_positioning_static;
 
-    object->index_pipeline_render = (
+    metil_object_hud->index_pipeline_render = (
       c938_pipeline_index_hud_item
     );
+
+    struct metil_renderer_data_object* metil_renderer_data_object_hud;
+
+    switch (
+      index_renderable
+    ) {
+      case scene_gameplay_renderables_index_hud_boosted:
+        metil_renderer_data_object_hud = (
+          metil_object_hud->buffers_vertex[
+            metil_object_buffer_default_index_data
+          ].buffer.contents
+        );
+
+        metil_renderer_data_object_hud->noise = 2000;
+
+        metil_object_hud->position.x = -0.9f;
+        metil_object_hud->position.y = -0.9f;
+        metil_object_hud->position.z = 0.0f;
+
+        break;
+      case scene_gameplay_renderables_index_hud_jumping:
+        metil_renderer_data_object_hud = (
+          metil_object_hud->buffers_vertex[
+            metil_object_buffer_default_index_data
+          ].buffer.contents
+        );
+
+        metil_renderer_data_object_hud->noise = 1;
+
+        metil_object_hud->position.x = -0.9f;
+        metil_object_hud->position.y = -0.8f;
+        metil_object_hud->position.z = 0.0f;
+
+        break;
+      case scene_gameplay_renderables_index_hud_jumping_secondary:
+        metil_renderer_data_object_hud = (
+          metil_object_hud->buffers_vertex[
+            metil_object_buffer_default_index_data
+          ].buffer.contents
+        );
+
+        metil_renderer_data_object_hud->noise = 2000;
+
+        metil_object_hud->position.x = -0.9f;
+        metil_object_hud->position.y = -0.7f;
+        metil_object_hud->position.z = 0.0f;
+
+        break;
+      default:
+        break;
+    }
   }
 
   scene->length_textures = 1;
@@ -231,91 +275,57 @@ void scene_gameplay_initialize(
 
   [texture_loader release];
 
-  object = scene->renderables[
-    scene_gameplay_renderables_index_player
-  ].renderable;
+  struct metil_group* metil_group_players = (
+    scene->renderables[
+      scene_gameplay_renderables_index_group_players
+    ].renderable
+  );
+
+  metil_group_add_length_initialize(
+    metil_group_players,
+    1,
+    metil_renderable_type_object
+  );
+
+  struct metil_object* metil_object_player = (
+    metil_group_players->renderables[
+      0
+    ]->renderable
+  );
+
+  metil_object_player->index_pipeline_render = (
+    c938_pipeline_index_player
+  );
 
   mesh_player_initialize(
-    &object->mesh,
+    &metil_object_player->mesh,
     &metil->player_defaults
   );
 
-  object->positioning = metil_positioning_player;
+  metil_object_player->positioning = (
+    metil_positioning_player
+  );
 
   metil_object_buffers_initialize(
-    object,
+    metil_object_player,
     metil->renderer_interface.metal_device
   );
 
   metil_object_texture_add(
-    object,
+    metil_object_player,
     scene->textures[
       scene_gameplay_textures_index_player
     ]
   );
 
-  struct metil_renderer_data_object* data = (
-    object->buffers_vertex[
-      metil_object_buffer_default_index_data
-    ].buffer.contents
-  );
-
-  object = (
-    scene->renderables[
-      scene_gameplay_renderables_index_hud_boosted
-    ].renderable
-  );
-
-  data = object->buffers_vertex[
-    metil_object_buffer_default_index_data
-  ].buffer.contents;
-
-  data->noise = 2000;
-
-  object->position.x = -0.9f;
-  object->position.y = -0.9f;
-  object->position.z = 0.0f;
-
-  object = (
-    scene->renderables[
-      scene_gameplay_renderables_index_hud_jumping
-    ].renderable
-  );
-
-  data = object->buffers_vertex[
-    metil_object_buffer_default_index_data
-  ].buffer.contents;
-
-  data->noise = 1.0f;
-
-  object->position.x = -0.9f;
-  object->position.y = -0.8f;
-  object->position.z = 0.0f;
-
-  object = (
-    scene->renderables[
-      scene_gameplay_renderables_index_hud_jumping_secondary
-    ].renderable
-  );
-
-  data = object->buffers_vertex[
-    metil_object_buffer_default_index_data
-  ].buffer.contents;
-
-  data->noise = 2000;
-
-  object->position.x = -0.9f;
-  object->position.y = -0.7f;
-  object->position.z = 0.0f;
-
-  object = (
+  struct metil_object* metil_object_crosshair = (
     scene->renderables[
       scene_gameplay_renderables_index_crosshair
     ].renderable
   );
 
   object_crosshair_initialize(
-    object,
+    metil_object_crosshair,
     metil->renderer_interface.metal_device
   );
 
@@ -557,6 +567,18 @@ void scene_gameplay_populate(
     metil->rendering_properties.camera.height
   );
 
+  struct metil_group* metil_group_players = (
+    scene->renderables[
+      scene_gameplay_renderables_index_group_players
+    ].renderable
+  );
+
+  struct metil_object* metil_object_player = (
+    metil_group_players->renderables[
+      0
+    ]->renderable
+  );
+
   if (
     (
       scene_gameplay_data->parameters->networked ==
@@ -607,12 +629,6 @@ void scene_gameplay_populate(
 
     scene_gameplay_data->length_enemies = (
       scene_gameplay_data->parameters->length_enemies
-    );
-
-    struct metil_object* metil_object_player = (
-      scene->renderables[
-        scene_gameplay_renderables_index_player
-      ].renderable
     );
 
     metil_object_player->position.y = (
@@ -771,19 +787,19 @@ void scene_gameplay_populate(
   );
 
   scene->player.position.x = object->position.x;
+  
   scene->player.position.y = (
     object->position.y +
     object->mesh.size.y
   );
-  scene->player.position.z = object->position.z;
 
-  object = (
-    scene->renderables[
-      scene_gameplay_renderables_index_player
-    ].renderable
+  scene->player.position.z = (
+    object->position.z
   );
 
-  object->position.y = scene->player.position.y;
+  metil_object_player->position.y = (
+    scene->player.position.y
+  );
 
   metil_group_destroy(
     metil,
@@ -1218,24 +1234,65 @@ void scene_gameplay_poll(
     metil_scene_gameplay
   );
 
-  struct metil_object* object = (
+  struct metil_group* metil_group_players = (
     metil_scene_gameplay->renderables[
-      scene_gameplay_renderables_index_player
+      scene_gameplay_renderables_index_group_players
     ].renderable
   );
 
-  object->position.x = metil_scene_gameplay->player.position.x;
-  object->position.y = metil_scene_gameplay->player.position.y;
-  object->position.z = metil_scene_gameplay->player.position.z;
+  struct metil_object* metil_object_player = (
+    metil_group_players->renderables[
+      0
+    ]->renderable
+  );
 
-  object = (
+  metil_object_player->position.x = (
+    metil_scene_gameplay->player.position.x
+  );
+
+  metil_object_player->position.y = (
+    metil_scene_gameplay->player.position.y -
+    metil->rendering_properties.camera.height +
+    metil_object_player->mesh.size.y / 
+    1.1
+  );
+
+  metil_object_player->position.z = (
+    metil_scene_gameplay->player.position.z
+  );
+
+  struct metil_object* metil_object_hud_boosted = (
     metil_scene_gameplay->renderables[
       scene_gameplay_renderables_index_hud_boosted
     ].renderable
   );
 
-  struct metil_renderer_data_object* data = (
-    object->buffers_vertex[
+  struct metil_renderer_data_object* metil_renderer_data_object_hud_boosted = (
+    metil_object_hud_boosted->buffers_vertex[
+      metil_object_buffer_default_index_data
+    ].buffer.contents
+  );
+
+  struct metil_object* metil_object_hud_jumping = (
+    metil_scene_gameplay->renderables[
+      scene_gameplay_renderables_index_hud_jumping
+    ].renderable
+  );
+
+  struct metil_renderer_data_object* metil_renderer_data_object_hud_jumping = (
+    metil_object_hud_jumping->buffers_vertex[
+      metil_object_buffer_default_index_data
+    ].buffer.contents
+  );
+
+  struct metil_object* metil_object_hud_jumping_secondary = (
+    metil_scene_gameplay->renderables[
+      scene_gameplay_renderables_index_hud_jumping_secondary
+    ].renderable
+  );
+
+  struct metil_renderer_data_object* metil_renderer_data_object_hud_jumping_secondary = (
+    metil_object_hud_jumping_secondary->buffers_vertex[
       metil_object_buffer_default_index_data
     ].buffer.contents
   );
@@ -1248,42 +1305,24 @@ void scene_gameplay_poll(
       player_data->time_boost
     );
 
-    data->noise = (
+    metil_renderer_data_object_hud_boosted->noise = (
       delta_time_boost > 2000
       ? 2000
       : delta_time_boost
     );
   } else {
-    data->noise = 2000;
+    metil_renderer_data_object_hud_boosted->noise = (
+      2000
+    );
   }
 
-  object = (
-    metil_scene_gameplay->renderables[
-      scene_gameplay_renderables_index_hud_jumping
-    ].renderable
-  );
-
-  data = object->buffers_vertex[
-    metil_object_buffer_default_index_data
-  ].buffer.contents;
-
-  data->noise = (
+  metil_renderer_data_object_hud_jumping->noise = (
     player_data->is_jumping != 0
     ? 0
     : 2000
   );
 
-  object = (
-    metil_scene_gameplay->renderables[
-      scene_gameplay_renderables_index_hud_jumping_secondary
-    ].renderable
-  );
-
-  data = object->buffers_vertex[
-    metil_object_buffer_default_index_data
-  ].buffer.contents;
-
-  data->noise = (
+  metil_renderer_data_object_hud_jumping_secondary->noise = (
     player_data->is_jumping_secondary != 0
     ? 0
     : 2000

--- a/sources/scenes/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay.m
@@ -2,6 +2,7 @@
 
 #include <c938_pipeline_index.h>
 #include <data/c938_data.h>
+#include <data/data_length.h>
 #include <data/enemy_data.h>
 #include <data/parameters_gameplay.h>
 #include <data/player_data.h>
@@ -20,6 +21,7 @@
 #include <player.h>
 #include <textures/textures_buildings.h>
 
+#include <clic3_bytes.h>
 #include <clic3_memory.h>
 
 #include <metil.h>
@@ -970,6 +972,12 @@ void scene_gameplay_poll(
     ].renderable
   );
 
+  struct metil_group* metil_group_players = (
+    metil_scene_gameplay->renderables[
+      scene_gameplay_renderables_index_group_players
+    ].renderable
+  );
+
   struct metil_group* metil_group_projectiles = (
     metil_scene_gameplay->renderables[
       scene_gameplay_renderables_index_projectiles
@@ -1032,6 +1040,138 @@ void scene_gameplay_poll(
       default: {
         break;
       }
+    }
+
+    if (
+      scene_gameplay_data->parameters->networked ==
+      parameters_gameplay_networked_client
+    ) {
+      pthread_mutex_lock(
+        &network_client->mutex_poll
+      );
+
+      if (
+        network_client->network_data_packet_poll != 0
+      ) {
+        unsigned int index_client;
+        unsigned int length_players;
+
+        network_data_packet_read(
+          network_client->network_data_packet_poll,
+          &index_client,
+          data_length_unsigned_int
+        );
+
+        network_data_packet_read(
+          network_client->network_data_packet_poll,
+          &length_players,
+          data_length_unsigned_int
+        );
+
+        if (
+          metil_group_players->length < length_players
+        ) {
+          unsigned int players_original = (
+            metil_group_players->length
+          );
+
+          unsigned int players_new = (
+            length_players -
+            players_original
+          );
+
+          metil_group_add_length_initialize(
+            metil_group_players,
+            players_new,
+            metil_renderable_type_object
+          );
+
+          for (
+            unsigned int index_player_new = players_original;
+            index_player_new < metil_group_players->length;
+            ++index_player_new
+          ) {
+            struct metil_object* metil_object_player = (
+              metil_group_players->renderables[
+                index_player_new
+              ]->renderable
+            );
+            
+            metil_object_player->index_pipeline_render = (
+              c938_pipeline_index_player
+            );
+
+            mesh_player_initialize(
+              &metil_object_player->mesh,
+              &metil->player_defaults
+            );
+
+            metil_object_buffers_initialize(
+              metil_object_player,
+              metil->renderer_interface.metal_device
+            );
+
+            metil_object_texture_add(
+              metil_object_player,
+              metil_scene_gameplay->textures[
+                scene_gameplay_textures_index_player
+              ]
+            );
+          }
+        }
+        
+        while (
+          metil_group_players->length > length_players
+        ) {
+          metil_group_destroy_renderable_at_index(
+            metil,
+            metil_group_players,
+            (
+              metil_group_players->length -
+              1
+            )
+          );
+        }
+
+        unsigned char offset_player = 0;
+
+        for (
+          unsigned int index_player = 0;
+          index_player < length_players;
+          ++index_player
+        ) {
+          if (
+            index_client == index_player
+          ) {
+            offset_player = 1;
+
+            network_client->network_data_packet_poll->offset = (
+              network_client->network_data_packet_poll->offset +
+              data_length_math_c_vector3_float
+            );
+
+            continue;
+          }
+
+          struct metil_object* metil_object_player = (
+            metil_group_players->renderables[
+              index_player +
+              1 -
+              offset_player
+            ]->renderable
+          );
+
+          network_data_packet_read(
+            network_client->network_data_packet_poll,
+            &metil_object_player->position,
+            data_length_math_c_vector3_float
+          );
+        }
+      }
+
+      pthread_mutex_unlock(
+        &network_client->mutex_poll
+      );
     }
 
     scene_gameplay_data->action_data_map = (
@@ -1234,12 +1374,6 @@ void scene_gameplay_poll(
     metil_scene_gameplay
   );
 
-  struct metil_group* metil_group_players = (
-    metil_scene_gameplay->renderables[
-      scene_gameplay_renderables_index_group_players
-    ].renderable
-  );
-
   struct metil_object* metil_object_player = (
     metil_group_players->renderables[
       0
@@ -1260,6 +1394,82 @@ void scene_gameplay_poll(
   metil_object_player->position.z = (
     metil_scene_gameplay->player.position.z
   );
+
+  if (
+    scene_gameplay_data->parameters->networked !=
+    parameters_gameplay_networked_none
+  ) {
+    struct c938_data* c938_data = (
+      metil->data
+    );
+
+    if (
+      scene_gameplay_data->parameters->networked ==
+      parameters_gameplay_networked_client
+    ) {
+      struct network_client* network_client = &(
+        c938_data->network_client
+      );
+
+      static struct network_data_packet* network_data_packet;
+      
+      network_data_packet =(
+        clic3_memory_allocate_raw(
+          sizeof(
+            struct network_data_packet
+          )
+        )
+      );
+
+      network_data_packet_initialize(
+        network_data_packet,
+        network_command_poll,
+        sizeof(
+          struct math_c_vector3_float
+        )
+      );
+
+      network_data_packet_bytes_add(
+        network_data_packet,
+        &metil_scene_gameplay->player.position,
+        sizeof(
+          struct math_c_vector3_float
+        )
+      );
+
+      network_client_send(
+        &c938_data->network_client,
+        network_data_packet
+      );
+    } else if (
+      scene_gameplay_data->parameters->networked ==
+      parameters_gameplay_networked_host
+    ) {
+      struct network_host* network_host = &(
+        c938_data->network_host
+      );
+
+      pthread_mutex_lock(
+        &network_host->mutex_position
+      );
+
+      clic3_bytes_copy(
+        &network_host->position,
+        &metil_scene_gameplay->player.position,
+        sizeof(
+          struct math_c_vector3_float
+        )
+      );
+
+      pthread_mutex_unlock(
+        &network_host->mutex_position
+      );
+
+      network_host_send_poll(
+        &c938_data->network_host
+      );
+    }
+  }
 
   struct metil_object* metil_object_hud_boosted = (
     metil_scene_gameplay->renderables[
@@ -1569,7 +1779,7 @@ OSStatus scene_gameplay_io_proc(
 
     unsigned long int size_buffer_out = (
       audio_buffer_current.mDataByteSize /
-      sizeof(float)
+      data_length_float
     );
 
     unsigned long int count_channel_out = (

--- a/sources/scenes/scene_menu_main/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main/scene_menu_main.m
@@ -1843,11 +1843,6 @@ void network_client_notification(
     data
   );
 
-  c938_logging_log(
-    metil,
-    notification
-  );
-
   enum network_client_notification_type network_client_notification_type =  (
     id_notification
   );
@@ -1883,6 +1878,9 @@ void network_client_notification(
 
       break;
     }
+    case network_client_notification_type_poll: {
+      return;
+    }
     case network_client_notification_type_default:
     default: {
       colour = clic3_colours_bold_blue;
@@ -1890,6 +1888,11 @@ void network_client_notification(
       break;
     }
   }
+
+  c938_logging_log(
+    metil,
+    notification
+  );
 
   network_notification_log_to_stream(
     stream_output,


### PR DESCRIPTION

https://github.com/user-attachments/assets/37f3f41c-3c0e-4747-8dd9-628e17d21c1e

player movement

for clients player objects are dynamically added and removed based on connected clients to the host (for hosts i need to add that in)

players send their position every frame, hosts send a data packet containing all connected clients positions every frame