### PR TITLE
[enh] `sockets`::network client target building checks

### DIFF
--- a/sources/player/player.m
+++ b/sources/player/player.m
@@ -482,7 +482,7 @@ void player_poll_input(
     .y = player->size.z / 2.0f
   };
 
-  struct metil_object* object = (void*)0;
+  struct metil_object* object = 0;
 
   for (
     unsigned int index_renderable = 0;

--- a/sources/scenes/scene_gameplay/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay/scene_gameplay.m
@@ -1133,10 +1133,6 @@ void scene_gameplay_poll(
           ]->renderable
         );
 
-        pthread_mutex_lock(
-          &network_host->mutex_thread
-        );
-
         for (
           unsigned int index_client = offset_network_host_client;
           index_client < network_host->length_clients;
@@ -1168,22 +1164,61 @@ void scene_gameplay_poll(
               network_host_client->position.z
             );
 
+            pthread_mutex_unlock(
+              &network_host_client->mutex_position
+            );
+
             offset_network_host_client = (
               index_client +
               1
             );
 
-            pthread_mutex_unlock(
-              &network_host_client->mutex_position
+            struct metil_object* metil_object_building = (
+              metil_group_buildings->renderables[
+                player_data->index_target_building
+              ]->renderable
             );
+
+            if (
+              metil_object_player->position.y == (
+                metil_object_building->position.y +
+                metil_object_building->mesh.size.y
+              )
+            ) {
+              struct math_c_vector2_float size_half_object = {
+                .x = metil_object_building->mesh.size.x / 2.0f,
+                .y = metil_object_building->mesh.size.z / 2.0f
+              };
+
+              struct math_c_vector2_float position_minimum_object = {
+                .x = metil_object_building->position.x - size_half_object.x,
+                .y = metil_object_building->position.z - size_half_object.y
+              };
+
+              struct math_c_vector2_float position_maximum_object = {
+                .x = metil_object_building->position.x + size_half_object.x,
+                .y = metil_object_building->position.z + size_half_object.y
+              };
+
+              if (
+                metil_object_player->position.x >= position_minimum_object.x - metil_object_player->mesh.size.x &&
+                metil_object_player->position.x <= position_maximum_object.x + metil_object_player->mesh.size.x &&
+                metil_object_player->position.z >= position_minimum_object.y - metil_object_player->mesh.size.z &&
+                metil_object_player->position.z <= position_maximum_object.y + metil_object_player->mesh.size.z
+              ) {
+                scene_gameplay_populate(
+                  metil,
+                  metil_scene_gameplay,
+                  0
+                );
+
+                return;
+              }
+            }
 
             break;
           }
         }
-
-        pthread_mutex_unlock(
-          &network_host->mutex_thread
-        );
       }
     }
 
@@ -1193,6 +1228,8 @@ void scene_gameplay_poll(
   }
   
   if (
+    scene_gameplay_data->parameters->networked !=
+    parameters_gameplay_networked_client &&
     player_data->on_ground == (
       player_data->index_target_building +
       1


### PR DESCRIPTION
repopulates the scene and sends the data map to all connected clients if a clients position is on the target building

https://github.com/user-attachments/assets/fa5ef2da-23c1-442d-a8b2-d5a96d3cff52

