### PR TITLE
[enh] Sockets :: make host tank

### DIFF
--- a/include/data/enemy_data.h
+++ b/include/data/enemy_data.h
@@ -9,7 +9,6 @@ struct enemy_data {
   unsigned char life_maximum;
   unsigned char life;
 
-  simd_float4 translation;
   float speed; // metres per second
 
   struct math_c_vector3_float position_previous;

--- a/include/network/network_client.h
+++ b/include/network/network_client.h
@@ -18,7 +18,8 @@ enum network_client_notification_type {
   network_client_notification_type_default = 0,
   network_client_notification_type_error = 1,
   network_client_notification_type_data_map_sent = 2,
-  network_client_notification_type_poll = 3
+  network_client_notification_type_poll = 3,
+  network_client_notification_type_enemies = 4
 };
 
 struct network_client {
@@ -44,6 +45,7 @@ struct network_client {
   pthread_mutex_t mutex_sending;
   pthread_mutex_t mutex_thread_sending;
   pthread_mutex_t mutex_network_data_packets_outgoing;
+  pthread_mutex_t mutex_enemies;
   pthread_mutex_t mutex_poll;
   pthread_mutex_t mutex_shots_fired;
 
@@ -52,6 +54,7 @@ struct network_client {
 
   unsigned int connected_players;
 
+  struct network_data_packet* network_data_packet_enemies;
   struct network_data_packet* network_data_packet_poll;
 
   struct network_data_shot_fired* shots_fired;

--- a/include/network/network_command.h
+++ b/include/network/network_command.h
@@ -7,7 +7,8 @@ enum network_command {
   network_command_data_map = 0x02,
   network_command_data_map_loaded = 0x03,
   network_command_poll = 0x04,
-  network_command_disconnecting = 0x05,
+  network_command_enemies = 0x05,
+  network_command_disconnecting = 0x06,
   network_command_error = 0xfe,
   network_command_unknown = 0xff
 };

--- a/include/scenes/scene_gameplay/scene_gameplay_group_enemies.h
+++ b/include/scenes/scene_gameplay/scene_gameplay_group_enemies.h
@@ -1,0 +1,13 @@
+#ifndef __c938_scenes_scene_gameplay_scene_gameplay_group_enemies_h
+#define __c938_scenes_scene_gameplay_scene_gameplay_group_enemies_h
+
+#include <metil.h>
+#include <metil_group.h>
+
+void scene_gameplay_group_enemies_resize(
+  struct metil* _Nonnull,
+  struct metil_group* _Nonnull,
+  unsigned int
+);
+
+#endif

--- a/sources/network/network_client.c
+++ b/sources/network/network_client.c
@@ -124,6 +124,7 @@ unsigned char network_client_connect_with_notification(
     &network_client->data_map
   );
 
+  network_client->network_data_packet_enemies = 0;
   network_client->network_data_packet_poll = 0;
 
   network_client->status = (
@@ -175,6 +176,11 @@ unsigned char network_client_connect_with_notification(
 
   pthread_mutex_init(
     &network_client->mutex_thread_sending,
+    0
+  );
+
+  pthread_mutex_init(
+    &network_client->mutex_enemies,
     0
   );
 
@@ -348,7 +354,39 @@ void* network_client_receiving_thread(
 
         break;
       }
-      case network_command_poll:
+      case network_command_enemies: {
+        pthread_mutex_lock(
+          &network_client->mutex_enemies
+        );
+
+        if (
+          network_client->network_data_packet_enemies != 0
+        ) {
+          network_data_packet_destroy(
+            network_client->network_data_packet_enemies
+          );
+
+          clic3_memory_free_raw(
+            network_client->network_data_packet_enemies
+          );
+        }
+
+        network_client->network_data_packet_enemies = (
+          network_data_packet
+        );
+
+        pthread_mutex_unlock(
+          &network_client->mutex_enemies
+        );
+
+        notification_manager_send(
+          &network_client->notification_manager,
+          "network_client::enemies",
+          network_client_notification_type_enemies
+        );
+        break;
+      }
+      case network_command_poll: {
         pthread_mutex_lock(
           &network_client->mutex_poll
         );
@@ -379,6 +417,7 @@ void* network_client_receiving_thread(
           network_client_notification_type_poll
         );
         break;
+      }
       case network_command_initialize:
       case network_command_no_operation:
       default: {
@@ -663,6 +702,10 @@ void network_client_destroy(
   );
 
   pthread_mutex_destroy(
+    &network_client->mutex_enemies
+  );
+
+  pthread_mutex_destroy(
     &network_client->mutex_poll
   );
 
@@ -673,6 +716,30 @@ void network_client_destroy(
   pthread_mutex_destroy(
     &network_client->mutex_shots_fired
   );
+
+  if (
+    network_client->network_data_packet_poll != 0
+  ) {
+    network_data_packet_destroy(
+      network_client->network_data_packet_poll
+    );
+
+    clic3_memory_free_raw(
+      network_client->network_data_packet_poll
+    );
+  }
+
+  if (
+    network_client->network_data_packet_enemies != 0
+  ) {
+    network_data_packet_destroy(
+      network_client->network_data_packet_enemies
+    );
+
+    clic3_memory_free_raw(
+      network_client->network_data_packet_enemies
+    );
+  }
 
   for (
     unsigned int index_network_data_packet_outgoing = 0;

--- a/sources/objects/object_enemy.m
+++ b/sources/objects/object_enemy.m
@@ -4,6 +4,7 @@
 #include <rendering/c938_pipeline_index.h>
 #include <data/enemy_data.h>
 #include <data/player_data.h>
+#include <data/scene_gameplay_data.h>
 
 #include <math_c_vector.h>
 
@@ -208,13 +209,22 @@ void object_enemy_poll(
     )->scene
   );
 
-  object_enemy_travel(
-    metil_object,
-    &metil_scene->player.position,
-    enemy_data,
-    &metil_scene->time_delta,
-    ((struct player_data*) metil_scene->player.data)->height
+  struct scene_gameplay_data* scene_gameplay_data = (
+    metil_scene->data
   );
+
+  if (
+    scene_gameplay_data->parameters->networked !=
+    parameters_gameplay_networked_client
+  ) {
+    object_enemy_travel(
+      metil_object,
+      &metil_scene->player.position,
+      enemy_data,
+      &metil_scene->time_delta,
+      ((struct player_data*) metil_scene->player.data)->height
+    );
+  }
 
   metil_positioning_view_model_matrix_projection_set(
     metil_object->positioning,

--- a/sources/scenes/scene_gameplay/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay/scene_gameplay.m
@@ -1778,6 +1778,99 @@ void scene_gameplay_poll(
     ? 0
     : 2000
   );
+
+  if (
+    scene_gameplay_data->parameters->networked ==
+    parameters_gameplay_networked_host
+  ) {
+    struct c938_data* c938_data = (
+      metil->data
+    );
+    
+    struct network_host* network_host = &(
+      c938_data->network_host
+    );
+  
+    struct network_data_packet network_data_packet_enemies;
+
+    network_data_packet_initialize(
+      &network_data_packet_enemies,
+      network_command_enemies,
+      (
+        data_length_unsigned_int +
+        metil_group_enemies->length * (
+          1 +
+          data_length_math_c_vector3_float
+        )
+      )
+    );
+
+    network_data_packet_bytes_add(
+      &network_data_packet_enemies,
+      &metil_group_enemies->length,
+      data_length_unsigned_int
+    );
+
+    for (
+      unsigned int index_enemy = 0;
+      index_enemy < metil_group_enemies->length;
+      ++index_enemy
+    ) {
+      struct metil_object* metil_object_enemies = (
+        metil_group_enemies->renderables[
+          index_enemy
+        ]->renderable
+      );
+
+      struct enemy_data* enemy_data = (
+        metil_object_enemies->buffers_vertex[
+          metil_object_buffer_default_index_data
+        ].buffer.contents
+      );
+
+      network_data_packet_bytes_add(
+        &network_data_packet_enemies,
+        &enemy_data->life,
+        1
+      );
+
+      network_data_packet_bytes_add(
+        &network_data_packet_enemies,
+        &metil_object_enemies->position,
+        data_length_math_c_vector3_float
+      );
+    }
+
+    for (
+      unsigned int index_network_host_client = 0;
+      index_network_host_client < network_host->length_clients;
+      ++index_network_host_client
+    ) {
+      struct network_host_client* network_host_client = (
+        network_host->clients[
+          index_network_host_client
+        ]
+      );
+
+      if (
+        (
+          network_host_client->status &
+          network_client_status_connected
+        ) == 0
+      ) {
+        continue;
+      }
+
+      network_data_packet_send(
+        &network_data_packet_enemies,
+        network_host_client->socket
+      );
+    }
+
+    network_data_packet_destroy(
+      &network_data_packet_enemies
+    );
+  }
 }
 
 void scene_gameplay_destroy(

--- a/sources/scenes/scene_gameplay/scene_gameplay.m
+++ b/sources/scenes/scene_gameplay/scene_gameplay.m
@@ -21,6 +21,7 @@
 #include <objects/object_player.h>
 #include <objects/object_projectile.h>
 #include <player/player.h>
+#include <scenes/scene_gameplay/scene_gameplay_group_enemies.h>
 #include <scenes/scene_gameplay/scene_gameplay_group_players.h>
 #include <textures/textures_buildings.h>
 
@@ -1169,6 +1170,78 @@ void scene_gameplay_poll(
       pthread_mutex_unlock(
         &network_client->mutex_poll
       );
+
+      pthread_mutex_lock(
+        &network_client->mutex_enemies
+      );
+
+      if (
+        network_client->network_data_packet_enemies != 0
+      ) {
+        unsigned int length_enemies;
+
+        network_data_packet_read(
+          network_client->network_data_packet_enemies,
+          &length_enemies,
+          data_length_unsigned_int
+        );
+
+        scene_gameplay_group_enemies_resize(
+          metil,
+          metil_group_enemies,
+          length_enemies
+        );
+
+        for (
+          unsigned int index_enemy = 0;
+          index_enemy < length_enemies;
+          ++index_enemy
+        ) {
+          struct metil_object* metil_object_enemy = (
+            metil_group_enemies->renderables[
+              index_enemy
+            ]->renderable
+          );
+
+          struct enemy_data* enemy_data = (
+            metil_object_enemy->buffers_vertex[
+              metil_object_buffer_default_index_data
+            ].buffer.contents
+          );
+
+          network_data_packet_read(
+            network_client->network_data_packet_enemies,
+            &enemy_data->life,
+            1
+          );
+
+          network_data_packet_read(
+            network_client->network_data_packet_enemies,
+            &metil_object_enemy->position,
+            data_length_math_c_vector3_float
+          );
+
+          network_data_packet_read(
+            network_client->network_data_packet_enemies,
+            &enemy_data->speed,
+            data_length_float
+          );
+        }
+
+        network_data_packet_destroy(
+          network_client->network_data_packet_enemies
+        );
+
+        clic3_memory_free_raw(
+          network_client->network_data_packet_enemies
+        );
+
+        network_client->network_data_packet_enemies = 0;
+      }
+
+      pthread_mutex_unlock(
+        &network_client->mutex_enemies
+      );
     } else if (
       scene_gameplay_data->parameters->networked ==
       parameters_gameplay_networked_host
@@ -1344,51 +1417,56 @@ void scene_gameplay_poll(
       0
     );
 
-    for (
-      unsigned int index_enemy = 0;
-      index_enemy < metil_group_enemies->length;
-      ++index_enemy
+    if (
+      scene_gameplay_data->parameters->networked !=
+      parameters_gameplay_networked_client
     ) {
-      struct metil_object* metil_object_enemy = (
-        metil_group_enemies->renderables[
-          index_enemy
-        ]->renderable
-      );
-
-      if (
-        metil_object_projectile->position.x >= metil_object_enemy->position.x - (metil_object_enemy->mesh.size.x / 2.0f) &&
-        metil_object_projectile->position.x <= metil_object_enemy->position.x + (metil_object_enemy->mesh.size.x / 2.0f) &&
-
-        metil_object_projectile->position.y >= metil_object_enemy->position.y - (metil_object_enemy->mesh.size.y / 2.0f) &&
-        metil_object_projectile->position.y <= metil_object_enemy->position.y + (metil_object_enemy->mesh.size.y / 2.0f) &&
-
-        metil_object_projectile->position.z >= metil_object_enemy->position.z - (metil_object_enemy->mesh.size.z / 2.0f) &&
-        metil_object_projectile->position.z <= metil_object_enemy->position.z + (metil_object_enemy->mesh.size.z / 2.0f)
+      for (
+        unsigned int index_enemy = 0;
+        index_enemy < metil_group_enemies->length;
+        ++index_enemy
       ) {
-        collision = 1;
-
-        struct enemy_data* enemy_data = (
-          metil_object_enemy->buffers_vertex[
-            metil_object_buffer_default_index_data
-          ].buffer.contents
-        );
-
-        enemy_data->life = (
-          enemy_data->life -
-          1
+        struct metil_object* metil_object_enemy = (
+          metil_group_enemies->renderables[
+            index_enemy
+          ]->renderable
         );
 
         if (
-          enemy_data->life <= 0
-        ) {
-          metil_group_destroy_renderable_at_index(
-            metil,
-            metil_group_enemies,
-            index_enemy
-          );
-        }
+          metil_object_projectile->position.x >= metil_object_enemy->position.x - (metil_object_enemy->mesh.size.x / 2.0f) &&
+          metil_object_projectile->position.x <= metil_object_enemy->position.x + (metil_object_enemy->mesh.size.x / 2.0f) &&
 
-        break;
+          metil_object_projectile->position.y >= metil_object_enemy->position.y - (metil_object_enemy->mesh.size.y / 2.0f) &&
+          metil_object_projectile->position.y <= metil_object_enemy->position.y + (metil_object_enemy->mesh.size.y / 2.0f) &&
+
+          metil_object_projectile->position.z >= metil_object_enemy->position.z - (metil_object_enemy->mesh.size.z / 2.0f) &&
+          metil_object_projectile->position.z <= metil_object_enemy->position.z + (metil_object_enemy->mesh.size.z / 2.0f)
+        ) {
+          collision = 1;
+
+          struct enemy_data* enemy_data = (
+            metil_object_enemy->buffers_vertex[
+              metil_object_buffer_default_index_data
+            ].buffer.contents
+          );
+
+          enemy_data->life = (
+            enemy_data->life -
+            1
+          );
+
+          if (
+            enemy_data->life <= 0
+          ) {
+            metil_group_destroy_renderable_at_index(
+              metil,
+              metil_group_enemies,
+              index_enemy
+            );
+          }
+
+          break;
+        }
       }
     }
 
@@ -1800,7 +1878,8 @@ void scene_gameplay_poll(
         data_length_unsigned_int +
         metil_group_enemies->length * (
           1 +
-          data_length_math_c_vector3_float
+          data_length_math_c_vector3_float +
+          data_length_float
         )
       )
     );
@@ -1838,6 +1917,12 @@ void scene_gameplay_poll(
         &network_data_packet_enemies,
         &metil_object_enemies->position,
         data_length_math_c_vector3_float
+      );
+
+      network_data_packet_bytes_add(
+        &network_data_packet_enemies,
+        &enemy_data->speed,
+        data_length_float
       );
     }
 

--- a/sources/scenes/scene_gameplay/scene_gameplay_group_enemies.m
+++ b/sources/scenes/scene_gameplay/scene_gameplay_group_enemies.m
@@ -1,0 +1,70 @@
+#include <scenes/scene_gameplay/scene_gameplay_group_enemies.h>
+
+#include <objects/object_enemy.h>
+
+#include <metil.h>
+#include <metil_group.h>
+#include <metil_object/metil_object.h>
+#include <metil_rendering/metil_renderable.h>
+
+void scene_gameplay_group_enemies_resize(
+  struct metil* metil,
+  struct metil_group* metil_group_enemies,
+  unsigned int length_enemies
+) {
+  if (
+    metil_group_enemies->length < length_enemies
+  ) {
+    unsigned int enemies_original = (
+      metil_group_enemies->length
+    );
+
+    unsigned int enemies_new = (
+      length_enemies -
+      enemies_original
+    );
+
+    metil_group_add_length_initialize(
+      metil_group_enemies,
+      enemies_new,
+      metil_renderable_type_object
+    );
+
+    for (
+      unsigned int index_enemy_new = enemies_original;
+      index_enemy_new < metil_group_enemies->length;
+      ++index_enemy_new
+    ) {
+      struct metil_object* metil_object_enemy = (
+        metil_group_enemies->renderables[
+          index_enemy_new
+        ]->renderable
+      );
+      
+      object_enemy_initialize(
+        metil_object_enemy,
+        metil->renderer_interface.metal_device,
+        (struct math_c_vector3_float) {
+          .x = 0,
+          .y = 0,
+          .z = 0
+        },
+        4,
+        0.0f
+      );
+    }
+  } else {
+    while (
+      metil_group_enemies->length > length_enemies
+    ) {
+      metil_group_destroy_renderable_at_index(
+        metil,
+        metil_group_enemies,
+        (
+          metil_group_enemies->length -
+          1
+        )
+      );
+    }
+  }
+}

--- a/sources/scenes/scene_menu_main/scene_menu_main.m
+++ b/sources/scenes/scene_menu_main/scene_menu_main.m
@@ -1878,6 +1878,7 @@ void network_client_notification(
 
       break;
     }
+    case network_client_notification_type_enemies:
     case network_client_notification_type_poll: {
       return;
     }


### PR DESCRIPTION
enemy movement and health is synchronized to all clients

host acts as a tank

controlling as a host (middle)

https://github.com/user-attachments/assets/d9d5160f-295b-4446-9aa9-cf357cc6374e

controlling as a client (top middle)

https://github.com/user-attachments/assets/590fc1dd-fd41-436f-a440-6c07aaad4dae

