### PR TITLE
[dev] `audio/io_procs/io_proc_scene_gameplay`:refactor_to_use_defines_instead_of_globals

### DIFF
--- a/include/audio/io_procs/io_proc_scene_gameplay.h
+++ b/include/audio/io_procs/io_proc_scene_gameplay.h
@@ -9,6 +9,9 @@
 #include <CoreAudio/CoreAudio.h>
 #endif
 
+#define c938_audio_io_proc_scene_gameplay_length_time_switch 0x0064
+#define c938_audio_io_proc_scene_gameplay_length_time_life   0x03e8
+
 float c938_audio_io_proc_scene_gameplay_frame_get(
   struct scene_gameplay_data*,
   unsigned long int,

--- a/sources/audio/io_procs/io_proc_scene_gameplay.m
+++ b/sources/audio/io_procs/io_proc_scene_gameplay.m
@@ -15,9 +15,6 @@
 #include <CoreAudio/CoreAudio.h>
 #endif
 
-unsigned int b = 100;
-unsigned int d = 1000;
-
 float c938_audio_io_proc_scene_gameplay_frame_get(
   struct scene_gameplay_data* scene_gameplay_data,
   unsigned long int time_current,
@@ -43,29 +40,29 @@ float c938_audio_io_proc_scene_gameplay_frame_get(
       ]
     );
 
-    unsigned long int v = (
+    unsigned long int time_alive = (
       time_current -
       time_fired
     );
 
-    float a = (
+    float value_additive = (
       0x00
     );
 
     if (
-      v <=
-      b
+      time_alive <=
+      c938_audio_io_proc_scene_gameplay_length_time_switch
     ) {
-      a = (
+      value_additive = (
         (float)
         (
           (
-            b -
-            v
+            c938_audio_io_proc_scene_gameplay_length_time_switch -
+            time_alive
           ) /
           (
             (float)
-            b /
+            c938_audio_io_proc_scene_gameplay_length_time_switch /
             2.0f
           ) -
           1.0f
@@ -73,8 +70,8 @@ float c938_audio_io_proc_scene_gameplay_frame_get(
       );
     } else {
       if (
-        v >
-        d
+        time_alive >
+        c938_audio_io_proc_scene_gameplay_length_time_life
       ) {
         for (
           unsigned int index_projectile_shift = (
@@ -107,15 +104,15 @@ float c938_audio_io_proc_scene_gameplay_frame_get(
         continue;
       }
 
-      a = (
+      value_additive = (
         (float)
         (
-          d -
-          v
+          c938_audio_io_proc_scene_gameplay_length_time_life -
+          time_alive
         ) /
         (
           (float)
-          d /
+          c938_audio_io_proc_scene_gameplay_length_time_life /
           2.0f -
           1.0f
         ) *
@@ -125,19 +122,19 @@ float c938_audio_io_proc_scene_gameplay_frame_get(
 
     if (
       (
-        v %
+        time_alive %
         0x02
       ) ==
       0x00
     ) {
-      a = (
-        -a
+      value_additive = (
+        -value_additive
       );
     }
 
     value = (
       value +
-      a
+      value_additive
     );
 
     index_projectile = (


### PR DESCRIPTION
- `audio/io_procs/io_proc_scene_gameplay`:refactor_to_use_defines_instead_of_globals

ill be changing the audio output to use `cer0` oscillators/synths at a later point in time